### PR TITLE
Added a Few Scripts + A Library Script

### DIFF
--- a/chord_toggle_visibility.lua
+++ b/chord_toggle_visibility.lua
@@ -1,0 +1,20 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Nick Mazuk"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "July 2, 2019"
+    finaleplugin.CategoryTags = "Chord"
+    finaleplugin.AuthorURL = "https://nickmazuk.com"
+    return "Toggle Chord Visibility", "Toggle Chord Visibility", "Toggles the chords' visibility"
+end
+
+local musicRegion = finenv.Region()
+musicRegion:SetCurrentSelection()
+local chords = finale.FCChords()
+chords:LoadAllForRegion(musicRegion)
+for chord in each(chords) do
+    chord.ChordVisible = not chord:GetChordVisible()
+    chord:Save()
+end
+

--- a/chord_toggle_visibility.lua
+++ b/chord_toggle_visibility.lua
@@ -9,12 +9,15 @@ function plugindef()
     return "Toggle Chord Visibility 2", "Toggle Chord Visibility 2", "Toggles the chords' visibility"
 end
 
-local musicRegion = finenv.Region()
-musicRegion:SetCurrentSelection()
-local chords = finale.FCChords()
-chords:LoadAllForRegion(musicRegion)
-for chord in each(chords) do
-    chord.ChordVisible = not chord:GetChordVisible()
-    chord:Save()
+function chord_toggle_visibility()
+    local musicRegion = finenv.Region()
+    musicRegion:SetCurrentSelection()
+    local chords = finale.FCChords()
+    chords:LoadAllForRegion(musicRegion)
+    for chord in each(chords) do
+        chord.ChordVisible = not chord:GetChordVisible()
+        chord:Save()
+    end
 end
 
+chord_toggle_visibility()

--- a/chord_toggle_visibility.lua
+++ b/chord_toggle_visibility.lua
@@ -6,7 +6,7 @@ function plugindef()
     finaleplugin.Date = "July 2, 2019"
     finaleplugin.CategoryTags = "Chord"
     finaleplugin.AuthorURL = "https://nickmazuk.com"
-    return "Toggle Chord Visibility", "Toggle Chord Visibility", "Toggles the chords' visibility"
+    return "Toggle Chord Visibility 2", "Toggle Chord Visibility 2", "Toggles the chords' visibility"
 end
 
 local musicRegion = finenv.Region()

--- a/expression_baseline_move_down.lua
+++ b/expression_baseline_move_down.lua
@@ -1,0 +1,44 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Nick Mazuk"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Date = "6/6/2020"
+    finaleplugin.CategoryTags = "Expression"
+    finaleplugin.AuthorURL = "https://nickmazuk.com"
+    return "Move Expression Baseline Down", "Move Expression Baseline Down",
+           "Moves the selected expression baseline down one space"
+end
+
+function ToEvpus(text)
+    local str = finale.FCString()
+    str.LuaString = text
+    return str:GetMeasurement(finale.MEASUREMENTUNIT_DEFAULT)
+end
+
+function expression_baseline_move_down()
+    local region = finenv.Region()
+    local systems = finale.FCStaffSystems()
+    systems:LoadAll()
+
+    local start_measure = region:GetStartMeasure()
+    local end_measure = region:GetEndMeasure()
+    local system = systems:FindMeasureNumber(start_measure)
+    local lastSys = systems:FindMeasureNumber(end_measure)
+    local system_number = system:GetItemNo()
+    local lastSys_number = lastSys:GetItemNo()
+    local start_staff = region:GetStartStaff()
+    local end_staff = region:GetEndStaff()
+
+    for i = system_number, lastSys_number, 1 do
+        local baselines = finale.FCBaselines()
+        baselines:LoadAllForSystem(finale.BASELINEMODE_EXPRESSIONABOVE, i)
+        for j = start_staff, end_staff, 1 do
+            bl = baselines:AssureSavedStaff(finale.BASELINEMODE_EXPRESSIONABOVE, i, j)
+            bl.VerticalOffset = bl.VerticalOffset - ToEvpus("1s")
+            bl:Save()
+        end
+    end
+end
+
+expression_baseline_move_down()

--- a/expression_baseline_move_up.lua
+++ b/expression_baseline_move_up.lua
@@ -1,0 +1,44 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Nick Mazuk"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Date = "6/6/2020"
+    finaleplugin.CategoryTags = "Expression"
+    finaleplugin.AuthorURL = "https://nickmazuk.com"
+    return "Move Expression Baseline Up", "Move Expression Baseline Up",
+           "Moves the selected expression baseline up one space"
+end
+
+function ToEvpus(text)
+    local str = finale.FCString()
+    str.LuaString = text
+    return str:GetMeasurement(finale.MEASUREMENTUNIT_DEFAULT)
+end
+
+function expression_baseline_move_up()
+    local region = finenv.Region()
+    local systems = finale.FCStaffSystems()
+    systems:LoadAll()
+
+    local start_measure = region:GetStartMeasure()
+    local end_measure = region:GetEndMeasure()
+    local system = systems:FindMeasureNumber(start_measure)
+    local lastSys = systems:FindMeasureNumber(end_measure)
+    local system_number = system:GetItemNo()
+    local lastSys_number = lastSys:GetItemNo()
+    local start_staff = region:GetStartStaff()
+    local end_staff = region:GetEndStaff()
+
+    for i = system_number, lastSys_number, 1 do
+        local baselines = finale.FCBaselines()
+        baselines:LoadAllForSystem(finale.BASELINEMODE_EXPRESSIONABOVE, i)
+        for j = start_staff, end_staff, 1 do
+            bl = baselines:AssureSavedStaff(finale.BASELINEMODE_EXPRESSIONABOVE, i, j)
+            bl.VerticalOffset = bl.VerticalOffset + ToEvpus("1s")
+            bl:Save()
+        end
+    end
+end
+
+expression_baseline_move_up()

--- a/library.lua
+++ b/library.lua
@@ -1,0 +1,10 @@
+-- A library of helpful JW Lua scripts
+-- Simply import this file to another Lua script to use any of these scripts
+local library = {}
+
+function library.change_octave(pitch_string, n)
+    pitch_string.LuaString = pitch_string.LuaString:sub(1, -2) .. (tonumber(string.sub(pitch_string.LuaString, -1)) + n)
+    return pitch_string
+end
+
+return library

--- a/pitch_entry_delete_bottom_note.lua
+++ b/pitch_entry_delete_bottom_note.lua
@@ -1,0 +1,22 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Nick Mazuk"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "June 7, 2020"
+    finaleplugin.CategoryTags = "Pitch"
+    finaleplugin.AuthorURL = "https://nickmazuk.com"
+    return "Chord Line - Delete Bottom Note", "Chord Line - Delete Bottom Note",
+           "Deletes the bottom note of every chord"
+end
+
+function pitch_entry_delete_bottom_note()
+    for entry in eachentrysaved(finenv.Region()) do
+        if (entry.Count >= 2) then
+            local bottom_note = entry:CalcLowestNote(nil)
+            entry:DeleteNote(bottom_note)
+        end
+    end
+end
+
+pitch_entry_delete_bottom_note()

--- a/pitch_entry_delete_top_note.lua
+++ b/pitch_entry_delete_top_note.lua
@@ -1,0 +1,21 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Nick Mazuk"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "June 7, 2020"
+    finaleplugin.CategoryTags = "Pitch"
+    finaleplugin.AuthorURL = "https://nickmazuk.com"
+    return "Chord Line - Delete Top Note", "Chord Line - Delete Top Note", "Deletes the top note of every chord"
+end
+
+function pitch_entry_delete_top_note()
+    for entry in eachentrysaved(finenv.Region()) do
+        if (entry.Count >= 2) then
+            local top_note = entry:CalcHighestNote(nil)
+            entry:DeleteNote(top_note)
+        end
+    end
+end
+
+pitch_entry_delete_top_note()

--- a/pitch_entry_double_octave_down.lua
+++ b/pitch_entry_double_octave_down.lua
@@ -9,6 +9,9 @@ function plugindef()
     return "Octave Doubling Down", "Octave Doubling Down", "Doubles the current note an octave lower"
 end
 
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local library = require("library")
 
 function pitch_entry_double_octave_down()

--- a/pitch_entry_double_octave_down.lua
+++ b/pitch_entry_double_octave_down.lua
@@ -1,0 +1,33 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Nick Mazuk"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "June 7, 2020"
+    finaleplugin.CategoryTags = "Pitch"
+    finaleplugin.AuthorURL = "https://nickmazuk.com"
+    return "Octave Doubling Down", "Octave Doubling Down", "Doubles the current note an octave lower"
+end
+
+local library = require("library")
+
+function pitch_entry_double_octave_down()
+    for entry in eachentrysaved(finenv.Region()) do
+        if (entry.Count == 1) then
+            local note = entry:CalcLowestNote(nil)
+            local pitch_string = finale.FCString()
+            local measure = entry:GetMeasure()
+            measure_object = finale.FCMeasure()
+            measure_object:Load(measure)
+            local keysig = measure_object:GetKeySignature()
+            note:GetString(pitch_string, keysig, false, false)
+            pitch_string = library.change_octave(pitch_string, -1)
+            local new_note = entry:AddNewNote()
+            new_note:SetString(pitch_string, keysig, false)
+            new_note.Tie = note.Tie
+            new_note.TieBackwards = note.TieBackwards
+        end
+    end
+end
+
+pitch_entry_double_octave_down()

--- a/pitch_entry_double_octave_up.lua
+++ b/pitch_entry_double_octave_up.lua
@@ -1,0 +1,33 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Nick Mazuk"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "June 7, 2020"
+    finaleplugin.CategoryTags = "Pitch"
+    finaleplugin.AuthorURL = "https://nickmazuk.com"
+    return "Octave Doubling Up", "Octave Doubling Up", "Doubles the current note an octave higher"
+end
+
+local library = require("library")
+
+function pitch_entry_double_octave_up()
+    for entry in eachentrysaved(finenv.Region()) do
+        if (entry.Count == 1) then
+            local note = entry:CalcLowestNote(nil)
+            local pitch_string = finale.FCString()
+            local measure = entry:GetMeasure()
+            measure_object = finale.FCMeasure()
+            measure_object:Load(measure)
+            local keysig = measure_object:GetKeySignature()
+            note:GetString(pitch_string, keysig, false, false)
+            pitch_string = library.change_octave(pitch_string, 1)
+            local new_note = entry:AddNewNote()
+            new_note:SetString(pitch_string, keysig, false)
+            new_note.Tie = note.Tie
+            new_note.TieBackwards = note.TieBackwards
+        end
+    end
+end
+
+pitch_entry_double_octave_up()

--- a/pitch_entry_double_octave_up.lua
+++ b/pitch_entry_double_octave_up.lua
@@ -9,6 +9,9 @@ function plugindef()
     return "Octave Doubling Up", "Octave Doubling Up", "Doubles the current note an octave higher"
 end
 
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local library = require("library")
 
 function pitch_entry_double_octave_up()

--- a/pitch_entry_keep_bottom_note.lua
+++ b/pitch_entry_keep_bottom_note.lua
@@ -1,0 +1,22 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Nick Mazuk"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "June 7, 2020"
+    finaleplugin.CategoryTags = "Pitch"
+    finaleplugin.AuthorURL = "https://nickmazuk.com"
+    return "Chord Line - Keep Bottom Note", "Chord Line - Keep Bottom Note",
+           "Keeps the bottom note of every chord and deletes the rest"
+end
+
+function pitch_entry_keep_bottom_note()
+    for entry in eachentrysaved(finenv.Region()) do
+        while (entry.Count >= 2) do
+            local top_note = entry:CalcHighestNote(nil)
+            entry:DeleteNote(top_note)
+        end
+    end
+end
+
+pitch_entry_keep_bottom_note()

--- a/pitch_entry_keep_top_note.lua
+++ b/pitch_entry_keep_top_note.lua
@@ -1,0 +1,22 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Nick Mazuk"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "June 7, 2020"
+    finaleplugin.CategoryTags = "Pitch"
+    finaleplugin.AuthorURL = "https://nickmazuk.com"
+    return "Chord Line - Keep Top Note", "Chord Line - Keep Top Note",
+           "Keeps the top note of every chord and deletes the rest"
+end
+
+function pitch_entry_keep_top_note()
+    for entry in eachentrysaved(finenv.Region()) do
+        while (entry.Count >= 2) do
+            local bottom_note = entry:CalcLowestNote(nil)
+            entry:DeleteNote(bottom_note)
+        end
+    end
+end
+
+pitch_entry_keep_top_note()


### PR DESCRIPTION
This pull request has two parts:

- 9 scripts
- Start of a reusable function library

Specifically, please check that `pitch_entry_double_octave_down.lua` and `pitch_entry_double_octave_up.lua` work.

These two scripts use `library.lua` for the helper function `change_octave`. These scripts work fine on my setup and theoretically should work wherever the local git repo is. But if you could check to see if the scripts work, that would validate that the import process isn't specific to my machine.

P.S. The function library is a JW Lua file that can house many common functions. That way, we can reuse previously written code for newer JW Lua scripts, speeding up development time, removing duplicate code, and lowering the barrier to entry for JW Lua.