### PR TITLE
fix a couple of issues with part switcher

### DIFF
--- a/UI_switch_to_selected_part.lua
+++ b/UI_switch_to_selected_part.lua
@@ -41,5 +41,8 @@ else
     --Finale manages to keep the selected region displayed when switching back to score, so nothing needs to be done here
     part:ViewInDocument()
    --scroll the selected region into view, because Finale sometimes loses track of it
-    ui:MoveToMeasure (music_region:GetStartMeasure(), music_region:GetStartStaff())
+    ui:MoveToMeasure (music_region:GetStartMeasure(), top_staff)
 end
+
+-- JW Lua sometimes adds to the Undo stack here, so suppress that behavior since we haven't changed anything
+finenv.StartNewUndoBlock("Switch To Selected Part", false)


### PR DESCRIPTION
1. If starting in page view on a part, the switcher failed to jump the correct page in score due to losing track of the selected staff

2. Don't put anything on the undo stack, since the script makes no document changes.