### PR TITLE
show the first part by order id in which the selected staff appears

### DIFF
--- a/UI_switch_to_selected_part.lua
+++ b/UI_switch_to_selected_part.lua
@@ -17,9 +17,11 @@ parts:LoadAll()
 local current_part = parts:GetCurrent()
 if current_part:IsScore() then
     local part_ID = nil
+    parts:SortByOrderID()
     for part in each(parts) do
-        if part:IsStaffIncluded(top_staff) then
+        if (not part:IsScore()) and part:IsStaffIncluded(top_staff) then
             part_ID = part:GetID()
+            break
         end
     end
     if part_ID ~= nil then


### PR DESCRIPTION
Refined so that if the selected staff appears in more than one part, the script switches to the first part with the staff as defined by the part's order id. (The order id is what determines its order in the parts menu.)

There's nothing like using a script in the real world to discover the kinks.