### PR TITLE
Rgp/measure numbers adjust for leadin

### DIFF
--- a/measure_numbers_adjust_for_leadin.lua
+++ b/measure_numbers_adjust_for_leadin.lua
@@ -64,7 +64,6 @@ function measure_numbers_adjust_for_leadin()
     local sel_region = finenv.Region()
 
     for system in each(systems) do
-        -- print ("system id = ", system.ItemNo, " timestamp ", os.time())
         local system_region = finale.FCMusicRegion()
         if system:CalcRegion(system_region) and system_region:IsOverlapping(sel_region) then
             -- getting metrics doesn't work for mm rests (past the first measure) but it takes a really big performance hit, so skip any that aren't first
@@ -90,7 +89,6 @@ function measure_numbers_adjust_for_leadin()
                                     -- if it did, we would subtract it here. Instead use the valus derived from document settings above.
                                     lead_in = lead_in - barline_thickness
                                     if (0 ~= lead_in) then
-                                        print ("    lead in found at cell ", cell.Measure, " ", cell.Staff, " timestamp ", os.time())
                                         lead_in = lead_in - additional_offset
                                         -- Finale scales the lead_in by the staff percent, so remove that if any
                                         local staff_percent = (cell_metrics.StaffScaling / 10000.0) / (cell_metrics.SystemScaling / 10000.0)

--- a/measure_numbers_adjust_for_leadin.lua
+++ b/measure_numbers_adjust_for_leadin.lua
@@ -21,11 +21,38 @@ local barline_thickness = math.floor(size_prefs.ThinBarlineThickness/64.0 + 0.5)
 
 local additional_offset = 0 -- add more here evpu to taste (positive values move the number to the right)
 
+local is_mid_system_default_number_visible = function (meas_num_region, cell, system, current_is_part)
+    if cell.Measure == system.FirstMeasure then
+        return false
+    end
+    if not meas_num_region:GetShowMultiples(current_is_part) then
+        return false
+    end
+    local staff = finale.FCCurrentStaffSpec()
+    if not staff:LoadForCell(cell, 0) then
+        return false
+    end
+    if staff.ShowMeasureNumbers then
+        return true
+    end
+    if meas_num_region:GetShowOnTopStaff() and (cell.Staff == system.TopStaff) then
+        return true
+    end
+    if meas_num_region:GetShowOnBottomStaff() and (cell.Staff == system:CalcBottomStaff()) then
+        return true
+    end
+    return false
+end
+
 function measure_numbers_adjust_for_leadin()
     local systems = finale.FCStaffSystems()
     systems:LoadAll()
     local meas_num_regions = finale.FCMeasureNumberRegions()
     meas_num_regions:LoadAll()
+    local parts = finale.FCParts()
+    parts:LoadAll()
+    local current_part = parts:GetCurrent()
+    local current_is_part = not current_part:IsScore()
 
     for meas_num, staff in eachcell(finenv.Region()) do
         local system = systems:FindMeasureNumber(meas_num)
@@ -35,38 +62,40 @@ function measure_numbers_adjust_for_leadin()
                 local cell_metrics = finale.FCCellMetrics()
                 local cell = finale.FCCell(meas_num, staff)
                 if cell_metrics:LoadAtCell(cell) and (cell_metrics.StaffScaling ~= 0) then --metrics are all zero for measures inside mm rests, so skip those
-                    -- a refinement would be to determine if measure numbers are showing on this staff and skip the cell if not
-                    local lead_in = cell_metrics.MusicStartPos - cell_metrics:GetLeftEdge()
-                    -- FCCellMetrics currently does not provide the barline width, which is available in the underlying PDK struct.
-                    -- if it did, we would subtract it here. Instead use the hard-coded value above
-                    lead_in = lead_in - barline_thickness
-                    if (0 ~= lead_in) then
-                        lead_in = lead_in - additional_offset
-                    end
-                    -- Finale scales the lead_in by the staff percent, so remove that if any
-                    local staff_percent = (cell_metrics.StaffScaling / 10000.0) / (cell_metrics.SystemScaling / 10000.0)
-                    lead_in = math.floor(lead_in/staff_percent + 0.5)
-                    -- FCSeparateMeasureNumber is scaled horizontally by the horizontal stretch, so back that out
-                    local horz_percent = cell_metrics.HorizontalStretch / 10000.0
-                    lead_in = math.floor(lead_in/horz_percent + 0.5)
-                    local sep_nums = finale.FCSeparateMeasureNumbers()
-                    sep_nums:LoadAllInCell(cell)
-                    if (sep_nums.Count > 0) then
-                        for sep_num in each(sep_nums) do
-                            sep_num.HorizontalPosition = -lead_in
-                            sep_num:Save()
+                    if is_mid_system_default_number_visible(meas_num_region, cell, system, current_is_part) then
+                        local lead_in = cell_metrics.MusicStartPos - cell_metrics:GetLeftEdge()
+                        -- FCCellMetrics currently does not provide the barline width, which is available in the underlying PDK struct.
+                        -- if it did, we would subtract it here. Instead use the valus derived from document settings above.
+                        lead_in = lead_in - barline_thickness
+                        if (0 ~= lead_in) then
+                            print ("lead in found at cell ", cell.Measure, " ", cell.Staff)
+                            lead_in = lead_in - additional_offset
+                            -- Finale scales the lead_in by the staff percent, so remove that if any
+                            local staff_percent = (cell_metrics.StaffScaling / 10000.0) / (cell_metrics.SystemScaling / 10000.0)
+                            lead_in = math.floor(lead_in/staff_percent + 0.5)
+                            -- FCSeparateMeasureNumber is scaled horizontally by the horizontal stretch, so back that out
+                            local horz_percent = cell_metrics.HorizontalStretch / 10000.0
+                            lead_in = math.floor(lead_in/horz_percent + 0.5)
                         end
-                    elseif (0 ~= lead_in) then
-                        local sep_num = finale.FCSeparateMeasureNumber()
-                        sep_num:ConnectCell(cell)
-                        sep_num:AssignMeasureNumberRegion(meas_num_region)
-                        sep_num.HorizontalPosition = -lead_in
-                        --sep_num:SetShowOverride(true) -- enable this line if you want to force show the number. It will be force shown on every selected staff
-                        if sep_num:SaveNew() then
-                            local measure = finale.FCMeasure()
-                            measure:Load(meas_num)
-                            measure:SetContainsManualMeasureNumbers(true)
-                            measure:Save()
+                        local sep_nums = finale.FCSeparateMeasureNumbers()
+                        sep_nums:LoadAllInCell(cell)
+                        if (sep_nums.Count > 0) then
+                            for sep_num in each(sep_nums) do
+                                sep_num.HorizontalPosition = -lead_in
+                                sep_num:Save()
+                            end
+                        elseif (0 ~= lead_in) then
+                            local sep_num = finale.FCSeparateMeasureNumber()
+                            sep_num:ConnectCell(cell)
+                            sep_num:AssignMeasureNumberRegion(meas_num_region)
+                            sep_num.HorizontalPosition = -lead_in
+                            --sep_num:SetShowOverride(true) -- enable this line if you want to force show the number. otherwise it will show or hide based on the measure number region
+                            if sep_num:SaveNew() then
+                                local measure = finale.FCMeasure()
+                                measure:Load(meas_num)
+                                measure:SetContainsManualMeasureNumbers(true)
+                                measure:Save()
+                            end
                         end
                     end
                 end

--- a/measure_numbers_adjust_for_leadin.lua
+++ b/measure_numbers_adjust_for_leadin.lua
@@ -1,0 +1,78 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Robert Patterson"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "June 19, 2020"
+    finaleplugin.CategoryTags = "Measure"
+    return "Measure Numbers Adjust for Key, Time, Repeat", "Measure Numbers Adjust for Key, Time, Repeat", "Adjusts all measure numbers left where there is a key signature, time signature, or start repeat."
+end
+
+-- Currently the PDK Framework does not appear to provide access to the true barline thickness per measure from the PDK metrics.
+-- As a subtitute this sets barline_thickness to your configured single barline thickness in your document prefs (in evpus)
+-- This will makes it right at least for single barlines.
+
+local size_prefs = finale.FCSizePrefs()
+size_prefs:Load(1)
+local barline_thickness = math.floor(size_prefs.ThinBarlineThickness/64.0 + 0.5) -- barline thickness in evpu
+
+-- additional_offset allows you to tweak the result. it is only applied if the measure is being moved, as opposed to barline_thickness
+-- which is always applied
+
+local additional_offset = 0 -- add more here evpu to taste (positive values move the number to the right)
+
+function measure_numbers_adjust_for_leadin()
+    local systems = finale.FCStaffSystems()
+    systems:LoadAll()
+    local meas_num_regions = finale.FCMeasureNumberRegions()
+    meas_num_regions:LoadAll()
+
+    for meas_num, staff in eachcell(finenv.Region()) do
+        local system = systems:FindMeasureNumber(meas_num)
+        local meas_num_region = meas_num_regions:FindMeasure(meas_num)
+        if (nil ~= system) and (nil ~= meas_num_region) then
+            if ( meas_num > system.FirstMeasure ) then
+                local cell_metrics = finale.FCCellMetrics()
+                local cell = finale.FCCell(meas_num, staff)
+                if cell_metrics:LoadAtCell(cell) and (cell_metrics.StaffScaling ~= 0) then --metrics are all zero for measures inside mm rests, so skip those
+                    -- a refinement would be to determine if measure numbers are showing on this staff and skip the cell if not
+                    local lead_in = cell_metrics.MusicStartPos - cell_metrics:GetLeftEdge()
+                    -- FCCellMetrics currently does not provide the barline width, which is available in the underlying PDK struct.
+                    -- if it did, we would subtract it here. Instead use the hard-coded value above
+                    lead_in = lead_in - barline_thickness
+                    if (0 ~= lead_in) then
+                        lead_in = lead_in - additional_offset
+                    end
+                    -- Finale scales the lead_in by the staff percent, so remove that if any
+                    local staff_percent = (cell_metrics.StaffScaling / 10000.0) / (cell_metrics.SystemScaling / 10000.0)
+                    lead_in = math.floor(lead_in/staff_percent + 0.5)
+                    -- FCSeparateMeasureNumber is scaled horizontally by the horizontal stretch, so back that out
+                    local horz_percent = cell_metrics.HorizontalStretch / 10000.0
+                    lead_in = math.floor(lead_in/horz_percent + 0.5)
+                    local sep_nums = finale.FCSeparateMeasureNumbers()
+                    sep_nums:LoadAllInCell(cell)
+                    if (sep_nums.Count > 0) then
+                        for sep_num in each(sep_nums) do
+                            sep_num.HorizontalPosition = -lead_in
+                            sep_num:Save()
+                        end
+                    elseif (0 ~= lead_in) then
+                        local sep_num = finale.FCSeparateMeasureNumber()
+                        sep_num:ConnectCell(cell)
+                        sep_num:AssignMeasureNumberRegion(meas_num_region)
+                        sep_num.HorizontalPosition = -lead_in
+                        --sep_num:SetShowOverride(true) -- enable this line if you want to force show the number. It will be force shown on every selected staff
+                        if sep_num:SaveNew() then
+                            local measure = finale.FCMeasure()
+                            measure:Load(meas_num)
+                            measure:SetContainsManualMeasureNumbers(true)
+                            measure:Save()
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+measure_numbers_adjust_for_leadin()

--- a/measure_numbers_adjust_for_leadin.lua
+++ b/measure_numbers_adjust_for_leadin.lua
@@ -10,23 +10,21 @@ end
 
 -- Currently the PDK Framework does not appear to provide access to the true barline thickness per measure from the PDK metrics.
 -- As a subtitute this sets barline_thickness to your configured single barline thickness in your document prefs (in evpus)
--- This will makes it right at least for single barlines.
+-- This makes it come out right at least for single barlines.
 
 local size_prefs = finale.FCSizePrefs()
 size_prefs:Load(1)
 local barline_thickness = math.floor(size_prefs.ThinBarlineThickness/64.0 + 0.5) -- barline thickness in evpu
 
--- additional_offset allows you to tweak the result. it is only applied if the measure is being moved, as opposed to barline_thickness
--- which is always applied
+-- additional_offset allows you to tweak the result. it is only applied if the measure number is being moved
 
-local additional_offset = 0 -- add more here evpu to taste (positive values move the number to the right)
+local additional_offset = 0 -- here you can add more evpu to taste (positive values move the number to the right)
 
-local is_mid_system_default_number_visible_and_left_aligned = function (meas_num_region, cell, system, current_is_part)
+local is_mid_system_default_number_visible_and_left_aligned = function (meas_num_region, cell, system, current_is_part, is_for_multimeasure_rest)
     if cell.Measure == system.FirstMeasure then
         return false
     end
-    multimeasure_rest = finale.FCMultiMeasureRest()
-    if meas_num_region:GetShowOnMultiMeasureRests(current_is_part) and multimeasure_rest:Load(cell.Measure) then
+    if is_for_multimeasure_rest and meas_num_region:GetShowOnMultiMeasureRests(current_is_part) then
         if (finale.MNALIGN_LEFT ~= meas_num_region:GetMultiMeasureAlignment(current_is_part)) then
             return false
         end
@@ -69,48 +67,58 @@ function measure_numbers_adjust_for_leadin()
         -- print ("system id = ", system.ItemNo, " timestamp ", os.time())
         local system_region = finale.FCMusicRegion()
         if system:CalcRegion(system_region) and system_region:IsOverlapping(sel_region) then
-            local cells = finale.FCCells()
-            cells:ApplyRegion(system_region)
-            for cell in each(cells) do
-                if (cell.Measure > system.FirstMeasure) and sel_region:IsMeasureIncluded(cell.Measure) and sel_region:IsStaffIncluded(cell.Staff) then
-                    local meas_num_region = meas_num_regions:FindMeasure(cell.Measure)
-                    if is_mid_system_default_number_visible_and_left_aligned(meas_num_region, cell, system, current_is_part) then
-                        print ("    metrics for cell ", cell.Measure, " ", cell.Staff, " time before metrics ", os.time())
-                        local cell_metrics = finale.FCCellMetrics()
-                        print ("    time after metrics ", os.time())
-                        if cell_metrics:LoadAtCell(cell) and (cell_metrics.StaffScaling ~= 0) then --metrics are all zero for measures inside mm rests, so skip those
-                            local lead_in = cell_metrics.MusicStartPos - cell_metrics:GetLeftEdge()
-                            -- FCCellMetrics currently does not provide the barline width, which is available in the underlying PDK struct.
-                            -- if it did, we would subtract it here. Instead use the valus derived from document settings above.
-                            lead_in = lead_in - barline_thickness
-                            if (0 ~= lead_in) then
-                                print ("    lead in found at cell ", cell.Measure, " ", cell.Staff, " timestamp ", os.time())
-                                lead_in = lead_in - additional_offset
-                                -- Finale scales the lead_in by the staff percent, so remove that if any
-                                local staff_percent = (cell_metrics.StaffScaling / 10000.0) / (cell_metrics.SystemScaling / 10000.0)
-                                lead_in = math.floor(lead_in/staff_percent + 0.5)
-                                -- FCSeparateMeasureNumber is scaled horizontally by the horizontal stretch, so back that out
-                                local horz_percent = cell_metrics.HorizontalStretch / 10000.0
-                                lead_in = math.floor(lead_in/horz_percent + 0.5)
-                            end
-                            local sep_nums = finale.FCSeparateMeasureNumbers()
-                            sep_nums:LoadAllInCell(cell)
-                            if (sep_nums.Count > 0) then
-                                for sep_num in each(sep_nums) do
-                                    sep_num.HorizontalPosition = -lead_in
-                                    sep_num:Save()
-                                end
-                            elseif (0 ~= lead_in) then
-                                local sep_num = finale.FCSeparateMeasureNumber()
-                                sep_num:ConnectCell(cell)
-                                sep_num:AssignMeasureNumberRegion(meas_num_region)
-                                sep_num.HorizontalPosition = -lead_in
-                                --sep_num:SetShowOverride(true) -- enable this line if you want to force show the number. otherwise it will show or hide based on the measure number region
-                                if sep_num:SaveNew() then
-                                    local measure = finale.FCMeasure()
-                                    measure:Load(cell.Measure)
-                                    measure:SetContainsManualMeasureNumbers(true)
-                                    measure:Save()
+            -- getting metrics doesn't work for mm rests (past the first measure) but it takes a really big performance hit, so skip any that aren't first
+            -- it is for this reason we are doing our own nested for loops instead of using for cell in each(cells)
+            local skip_past_meas_num = 0
+            for meas_num = system_region.StartMeasure+1, system_region.EndMeasure do
+                if (meas_num > skip_past_meas_num) and sel_region:IsMeasureIncluded(meas_num) then
+                    local meas_num_region = meas_num_regions:FindMeasure(meas_num)
+                    multimeasure_rest = finale.FCMultiMeasureRest()
+                    local is_for_multimeasure_rest = multimeasure_rest:Load(meas_num)
+                    if is_for_multimeasure_rest then
+                        skip_past_meas_num = multimeasure_rest.EndMeasure
+                    end
+                    for slot = system_region.StartSlot, system_region.EndSlot do
+                        local staff = system_region:CalcStaffNumber(slot)
+                        if sel_region:IsStaffIncluded(staff) then
+                            local cell = finale.FCCell(meas_num, staff)
+                            if is_mid_system_default_number_visible_and_left_aligned(meas_num_region, cell, system, current_is_part, is_for_multimeasure_rest) then
+                                local cell_metrics = finale.FCCellMetrics()
+                                if cell_metrics:LoadAtCell(cell) and (cell_metrics.StaffScaling ~= 0) then --metrics are all zero for measures inside mm rests, so skip those
+                                    local lead_in = cell_metrics.MusicStartPos - cell_metrics:GetLeftEdge()
+                                    -- FCCellMetrics currently does not provide the barline width, which is available in the underlying PDK struct.
+                                    -- if it did, we would subtract it here. Instead use the valus derived from document settings above.
+                                    lead_in = lead_in - barline_thickness
+                                    if (0 ~= lead_in) then
+                                        print ("    lead in found at cell ", cell.Measure, " ", cell.Staff, " timestamp ", os.time())
+                                        lead_in = lead_in - additional_offset
+                                        -- Finale scales the lead_in by the staff percent, so remove that if any
+                                        local staff_percent = (cell_metrics.StaffScaling / 10000.0) / (cell_metrics.SystemScaling / 10000.0)
+                                        lead_in = math.floor(lead_in/staff_percent + 0.5)
+                                        -- FCSeparateMeasureNumber is scaled horizontally by the horizontal stretch, so back that out
+                                        local horz_percent = cell_metrics.HorizontalStretch / 10000.0
+                                        lead_in = math.floor(lead_in/horz_percent + 0.5)
+                                    end
+                                    local sep_nums = finale.FCSeparateMeasureNumbers()
+                                    sep_nums:LoadAllInCell(cell)
+                                    if (sep_nums.Count > 0) then
+                                        for sep_num in each(sep_nums) do
+                                            sep_num.HorizontalPosition = -lead_in
+                                            sep_num:Save()
+                                        end
+                                    elseif (0 ~= lead_in) then
+                                        local sep_num = finale.FCSeparateMeasureNumber()
+                                        sep_num:ConnectCell(cell)
+                                        sep_num:AssignMeasureNumberRegion(meas_num_region)
+                                        sep_num.HorizontalPosition = -lead_in
+                                        --sep_num:SetShowOverride(true) -- enable this line if you want to force show the number. otherwise it will show or hide based on the measure number region
+                                        if sep_num:SaveNew() then
+                                            local measure = finale.FCMeasure()
+                                            measure:Load(cell.Measure)
+                                            measure:SetContainsManualMeasureNumbers(true)
+                                            measure:Save()
+                                        end
+                                    end
                                 end
                             end
                         end


### PR DESCRIPTION
This is a new script to adjust left-aligned measure number for key, time, and repeat bar lead-in. It has been optimized and runs pretty well even on large documents.