### PR TITLE
added measure numbers move up/down scripts

### DIFF
--- a/library/general_library.lua
+++ b/library/general_library.lua
@@ -117,4 +117,22 @@ function library.get_top_left_selected_or_visible_cell()
     return library.get_top_left_visible_cell()
 end
 
+function library.is_default_measure_number_visible_on_cell (meas_num_region, cell, staff_system, current_is_part)
+    local staff = finale.FCCurrentStaffSpec()
+    if not staff:LoadForCell(cell, 0) then
+        return false
+    end
+    if meas_num_region:GetShowOnTopStaff() and (cell.Staff == staff_system.TopStaff) then
+        return true
+    end
+    if meas_num_region:GetShowOnBottomStaff() and (cell.Staff == staff_system:CalcBottomStaff()) then
+        return true
+    end
+    if staff.ShowMeasureNumbers then
+        return not meas_num_region:GetExcludeOtherStaves(current_is_part)
+    end
+    return false
+end
+
+
 return library

--- a/measure_numbers_adjust_for_leadin.lua
+++ b/measure_numbers_adjust_for_leadin.lua
@@ -1,5 +1,4 @@
 function plugindef()
-    finaleplugin.RequireSelection = true
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
     finaleplugin.Version = "1.0"
@@ -7,6 +6,11 @@ function plugindef()
     finaleplugin.CategoryTags = "Measure"
     return "Measure Numbers Adjust for Key, Time, Repeat", "Measure Numbers Adjust for Key, Time, Repeat", "Adjusts all measure numbers left where there is a key signature, time signature, or start repeat."
 end
+
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local library = require("library.general_library")
 
 -- Currently the PDK Framework does not appear to provide access to the true barline thickness per measure from the PDK metrics.
 -- As a subtitute this sets barline_thickness to your configured single barline thickness in your document prefs (in evpus)
@@ -36,20 +40,7 @@ local is_mid_system_default_number_visible_and_left_aligned = function (meas_num
             return false
         end
     end
-    local staff = finale.FCCurrentStaffSpec()
-    if not staff:LoadForCell(cell, 0) then
-        return false
-    end
-    if meas_num_region:GetShowOnTopStaff() and (cell.Staff == system.TopStaff) then
-        return true
-    end
-    if meas_num_region:GetShowOnBottomStaff() and (cell.Staff == system:CalcBottomStaff()) then
-        return true
-    end
-    if staff.ShowMeasureNumbers then
-        return not meas_num_region:GetExcludeOtherStaves(current_is_part)
-    end
-    return false
+    return library.is_default_measure_number_visible_on_cell (meas_num_region, cell, system, current_is_part)
 end
 
 function measure_numbers_adjust_for_leadin()
@@ -61,7 +52,7 @@ function measure_numbers_adjust_for_leadin()
     parts:LoadAll()
     local current_part = parts:GetCurrent()
     local current_is_part = not current_part:IsScore()
-    local sel_region = finenv.Region()
+    local sel_region = library.get_selected_region_or_whole_doc()
 
     for system in each(systems) do
         local system_region = finale.FCMusicRegion()

--- a/measure_numbers_move_down.lua
+++ b/measure_numbers_move_down.lua
@@ -1,0 +1,60 @@
+function plugindef()
+    finaleplugin.Author = "Robert Patterson"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "June 21, 2020"
+    finaleplugin.CategoryTags = "Measure"
+    return "Measure Numbers Move Down", "Measure Numbers Move Down", "Moves all measure numbers down by one staff space."
+end
+
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local library = require("library.general_library")
+
+local move_amount = -24 -- 24 evpus per staff space
+
+function measure_numbers_move_up()
+    local systems = finale.FCStaffSystems()
+    systems:LoadAll()
+    local meas_num_regions = finale.FCMeasureNumberRegions()
+    meas_num_regions:LoadAll()
+    local parts = finale.FCParts()
+    parts:LoadAll()
+    local current_part = parts:GetCurrent()
+    local current_is_part = not current_part:IsScore()
+    local sel_region = library.get_selected_region_or_whole_doc()
+
+    local cells = finale.FCCells()
+    cells:ApplyRegion(sel_region)
+    for cell in each(cells) do
+        local system = systems:FindMeasureNumber(cell.Measure)
+        local meas_num_region = meas_num_regions:FindMeasure(cell.Measure)
+        if (nil ~= system) and (nil ~= meas_num_region) then
+            if library.is_default_measure_number_visible_on_cell(meas_num_region, cell, system, current_is_part) then
+                local sep_nums = finale.FCSeparateMeasureNumbers()
+                sep_nums:LoadAllInCell(cell)
+                if (sep_nums.Count > 0) then
+                    for sep_num in each(sep_nums) do
+                        sep_num.VerticalPosition = sep_num.VerticalPosition + move_amount
+                        sep_num:Save()
+                    end
+                elseif (0 ~= lead_in) then
+                    local sep_num = finale.FCSeparateMeasureNumber()
+                    sep_num:ConnectCell(cell)
+                    sep_num:AssignMeasureNumberRegion(meas_num_region)
+                    sep_num.VerticalPosition = sep_num.VerticalPosition + move_amount
+                    --sep_num:SetShowOverride(true) -- enable this line if you want to force show the number. otherwise it will show or hide based on the measure number region
+                    if sep_num:SaveNew() then
+                        local measure = finale.FCMeasure()
+                        measure:Load(cell.Measure)
+                        measure:SetContainsManualMeasureNumbers(true)
+                        measure:Save()
+                    end
+                end
+            end
+        end
+    end
+end
+
+measure_numbers_move_up()

--- a/measure_numbers_move_up.lua
+++ b/measure_numbers_move_up.lua
@@ -1,0 +1,60 @@
+function plugindef()
+    finaleplugin.Author = "Robert Patterson"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "June 21, 2020"
+    finaleplugin.CategoryTags = "Measure"
+    return "Measure Numbers Move Up", "Measure Numbers Move Up", "Moves all measure numbers up by one staff space."
+end
+
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local library = require("library.general_library")
+
+local move_amount = 24 -- evpus
+
+function measure_numbers_move_up()
+    local systems = finale.FCStaffSystems()
+    systems:LoadAll()
+    local meas_num_regions = finale.FCMeasureNumberRegions()
+    meas_num_regions:LoadAll()
+    local parts = finale.FCParts()
+    parts:LoadAll()
+    local current_part = parts:GetCurrent()
+    local current_is_part = not current_part:IsScore()
+    local sel_region = library.get_selected_region_or_whole_doc()
+
+    local cells = finale.FCCells()
+    cells:ApplyRegion(sel_region)
+    for cell in each(cells) do
+        local system = systems:FindMeasureNumber(cell.Measure)
+        local meas_num_region = meas_num_regions:FindMeasure(cell.Measure)
+        if (nil ~= system) and (nil ~= meas_num_region) then
+            if library.is_default_measure_number_visible_on_cell(meas_num_region, cell, system, current_is_part) then
+                local sep_nums = finale.FCSeparateMeasureNumbers()
+                sep_nums:LoadAllInCell(cell)
+                if (sep_nums.Count > 0) then
+                    for sep_num in each(sep_nums) do
+                        sep_num.VerticalPosition = sep_num.VerticalPosition + move_amount
+                        sep_num:Save()
+                    end
+                elseif (0 ~= lead_in) then
+                    local sep_num = finale.FCSeparateMeasureNumber()
+                    sep_num:ConnectCell(cell)
+                    sep_num:AssignMeasureNumberRegion(meas_num_region)
+                    sep_num.VerticalPosition = sep_num.VerticalPosition + move_amount
+                    --sep_num:SetShowOverride(true) -- enable this line if you want to force show the number. otherwise it will show or hide based on the measure number region
+                    if sep_num:SaveNew() then
+                        local measure = finale.FCMeasure()
+                        measure:Load(cell.Measure)
+                        measure:SetContainsManualMeasureNumbers(true)
+                        measure:Save()
+                    end
+                end
+            end
+        end
+    end
+end
+
+measure_numbers_move_up()


### PR DESCRIPTION
Added scripts to move measure numbers up/down by a space. (This can easily be changed in the beginning of the script.) Also removed selection requirement.

All measure number scripts now depend on library.general_library.
