### PR TITLE
Add .mus, .musx, and script_settings to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ jwluatagfile.xml
 SciLexer.dll
 jwlua64.fxtco
 .vscode
+.mus
+.musx
+script_settings


### PR DESCRIPTION
Adds these files to the .gitignore.

Background: https://github.com/Nick-Mazuk/jw-lua-scripts/issues/42 https://github.com/Nick-Mazuk/jw-lua-scripts/issues/43

close https://github.com/Nick-Mazuk/jw-lua-scripts/issues/42