### PR TITLE
Rgp/parameters from text file

### DIFF
--- a/library/configuration.lua
+++ b/library/configuration.lua
@@ -1,0 +1,83 @@
+-- A collection of helpful JW Lua scripts to retrieve parameters from a text file
+-- Simply import this file to another Lua script to use any of these scripts
+--
+-- Author: Robert Patterson
+-- Date: March 5, 2021
+--
+-- This library implements a text file scheme as follows:
+-- Comments start with "--"
+-- Leading and trailing whitespace is ignored
+-- Each parameter is named and delimited by a colon as follows:
+--
+-- <parameter-name> = <parameter-value>
+--
+-- Parameter values must be numbers or booleans. (If we need strings, that can be an enhancement.)
+
+local configuration = {}
+
+local script_settings_dir = "script_settings" -- the parent of this directory is the running lua path
+local comment_marker = "--"
+local parameter_delimiter = "="
+local path_delimiter = "/"
+
+local file_exists = function(file_path)
+    local f = io.open(file_path,"r")
+    if nil ~= f then
+        io.close(f)
+        return true
+    end
+    return false
+end
+
+local strip_leading_trailing_whitespace = function (str)
+    return str:match("^%s*(.-)%s*$") -- regular expression magic taken from the Internet
+end
+
+local get_parameters_from_file = function(file_name)
+    local parameters = {}
+
+    local path = finale.FCString()
+    path:SetRunningLuaFolderPath()
+    local file_path = path.LuaString .. path_delimiter .. file_name
+    if not file_exists(file_path) then
+        return parameters
+    end
+
+    for line in io.lines(file_path) do
+        local comment_at = string.find(line, comment_marker, 1, true) -- true means use raw string rather than reg. exp.
+        if nil ~= comment_at then
+            line = string.sub(line, 1, comment_at-1)
+        end
+        local delimiter_at = string.find(line, parameter_delimiter, 1, true)
+        if nil ~= delimiter_at then
+            local name = strip_leading_trailing_whitespace(string.sub(line, 1, delimiter_at-1))
+            local val_string = strip_leading_trailing_whitespace(string.sub(line, delimiter_at+1))
+            if "true" == val_string then
+                parameters[name] = true
+            elseif "false" == val_string then
+                parameters[name] = false
+            else
+                parameters[name] = tonumber(val_string)
+            end
+        end
+    end
+    
+    return parameters
+end
+
+-- configuration.get_parameters
+-- file_name: the file name of the config file (which will be prepended with the script_settings_dir)
+-- parameter_list: a table with the parameter name as key and the default value as value
+function configuration.get_parameters(file_name, parameter_list)
+    local file_parameters = get_parameters_from_file(script_settings_dir .. path_delimiter .. file_name)
+    if nil ~= file_parameters then
+        for param_name, def_val in pairs(parameter_list) do
+            local param_val = file_parameters[param_name]
+            if nil ~= param_val then
+                parameter_list[param_name] = param_val
+            end
+        end
+    end
+end
+
+return configuration

--- a/standalone_hairpin_adjustment.lua
+++ b/standalone_hairpin_adjustment.lua
@@ -12,15 +12,19 @@ path:SetRunningLuaFolderPath()
 package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local expression = require("library.expression")
 local note_entry = require("library.note_entry")
+local configuration = require("library.configuration")
 
--- These parameters can be adjusted to suit any user's taste.
--- ToDo: optionally read them in from a text file, maybe?
+-- These parameters can be changed with a config.txt file
 
-local left_dynamic_cushion = 9              -- space between a dynamic and a hairpin on the left
-local right_dynamic_cushion = -9            -- space between a dynamic and a haripin on the right
-local left_selection_cushion = 0            -- currently not used
-local right_selection_cushion = 0           -- additional space between a hairpin and the end of its beat region
-local extend_to_end_of_right_entry = true   -- if true, extend hairpins through the end of their right note entries
+local config = {
+    left_dynamic_cushion = 9,                   -- space between a dynamic and a hairpin on the left
+    right_dynamic_cushion = -9,                 -- space between a dynamic and a haripin on the right
+    left_selection_cushion = 0,                 -- currently not used
+    right_selection_cushion = 0,                -- additional space between a hairpin and the end of its beat region
+    extend_to_end_of_right_entry = true         -- if true, extend hairpins through the end of their right note entries
+}
+
+configuration.get_parameters ("standalone_hairpin_adjustment.config.txt", config)
 
 -- end of parameters
 
@@ -228,18 +232,18 @@ function horizontal_hairpin_adjustment(left_or_right, hairpin, region_settings, 
         end
         local total_offset = expression.calc_handle_offset_for_smart_shape(dyn_exp)
         if left_or_right == "left" then
-            local total_x = dyn_width + left_dynamic_cushion + total_offset
+            local total_x = dyn_width + config.left_dynamic_cushion + total_offset
             the_seg:SetEndpointOffsetX(total_x)
         elseif left_or_right == "right" then
             cushion_bool = false
-            local total_x = (0 - dyn_width) + right_dynamic_cushion + total_offset
+            local total_x = (0 - dyn_width) + config.right_dynamic_cushion + total_offset
             the_seg:SetEndpointOffsetX(total_x)
         end
     end
     if cushion_bool then
         the_seg = hairpin:GetTerminateSegmentRight()
         local entry_width = 0
-        if extend_to_end_of_right_entry then
+        if config.extend_to_end_of_right_entry then
             region:SetStartMeasure(the_seg:GetMeasure())
             region:SetStartMeasurePos(the_seg:GetMeasurePos())
             region:SetEndMeasure(the_seg:GetMeasure())
@@ -251,7 +255,7 @@ function horizontal_hairpin_adjustment(left_or_right, hairpin, region_settings, 
                 end
             end
         end
-        the_seg:SetEndpointOffsetX(right_selection_cushion + entry_width)
+        the_seg:SetEndpointOffsetX(config.right_selection_cushion + entry_width)
     end
     hairpin:Save()
 end


### PR DESCRIPTION
Here is the configuration file feature. It has the following features:

- It is not dependent on format. Each parameter is named with the same name as in the script. If the script changes the parameter name, that value in the config file will be ignored.
- Parameters may be listed in any order in the config file, and they may also be omitted.
- Config files must be in a sub-directory of the running Lua path called `script_settings`.
- Config files may contain comments using `--` just as in the Lua language.
- Currently only numbers and boolean values (`true` or `false`) are supported. Strings can be a future enhancement.
- A config file is always optional. In the case when it is missing, the default values are used.

Here is a sample config file for the `standalone_hairpin_adjustments` lua script:
```

-- Comments can be here
--
--

left_dynamic_cushion = 24		--evpus
right_dynamic_cushion = -24		--evpus
extend_to_end_of_right_entry = false

```


