### PR TITLE
Rgp/adjust hairpin dyn refinements

### DIFF
--- a/library/configuration.lua
+++ b/library/configuration.lua
@@ -44,7 +44,7 @@ local get_parameters_from_file = function(file_name)
     end
 
     for line in io.lines(file_path) do
-        local comment_at = string.find(line, comment_marker, 1, true) -- true means use raw string rather than reg. exp.
+        local comment_at = string.find(line, comment_marker, 1, true) -- true means find raw string rather than lua pattern
         if nil ~= comment_at then
             line = string.sub(line, 1, comment_at-1)
         end

--- a/library/configuration.lua
+++ b/library/configuration.lua
@@ -11,7 +11,7 @@
 --
 -- <parameter-name> = <parameter-value>
 --
--- Parameter values must be numbers or booleans. (If we need strings, that can be an enhancement.)
+-- Parameter values must be numbers or booleans or strings.
 
 local configuration = {}
 
@@ -30,7 +30,7 @@ local file_exists = function(file_path)
 end
 
 local strip_leading_trailing_whitespace = function (str)
-    return str:match("^%s*(.-)%s*$") -- regular expression magic taken from the Internet
+    return str:match("^%s*(.-)%s*$") -- lua pattern magic taken from the Internet
 end
 
 local get_parameters_from_file = function(file_name)
@@ -52,7 +52,11 @@ local get_parameters_from_file = function(file_name)
         if nil ~= delimiter_at then
             local name = strip_leading_trailing_whitespace(string.sub(line, 1, delimiter_at-1))
             local val_string = strip_leading_trailing_whitespace(string.sub(line, delimiter_at+1))
-            if "true" == val_string then
+            if '"' == val_string:sub(1,1) and '"' == val_string:sub(#val_string,#val_string) then -- double-quote string
+                parameters[name] = string.gsub(val_string, '"(.+)"', "%1") -- lua pattern magic: "(.+)" matches all characters between two double-quote marks (no escape chars)
+            elseif "'" == val_string:sub(1,1) and "'" == val_string:sub(#val_string,#val_string) then -- single-quote string
+                parameters[name] = string.gsub(val_string, "'(.+)'", "%1") -- lua pattern magic: '(.+)' matches all characters between two single-quote marks (no escape chars)
+            elseif "true" == val_string then
                 parameters[name] = true
             elseif "false" == val_string then
                 parameters[name] = false

--- a/standalone_hairpin_adjustment.lua
+++ b/standalone_hairpin_adjustment.lua
@@ -2,7 +2,7 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "CJ Garcia"
     finaleplugin.Copyright = "© 2021 CJ Garcia Music"
-    finaleplugin.Version = "1.1"
+    finaleplugin.Version = "1.2"
     finaleplugin.Date = "2/29/2021"
     return "Hairpin and Dynamic Adjustments", "Hairpin and Dynamic Adjustments", "Adjusts hairpins to remove collisions with dynamics and aligns hairpins with dynamics."
 end

--- a/standalone_hairpin_adjustment.lua
+++ b/standalone_hairpin_adjustment.lua
@@ -17,14 +17,15 @@ local configuration = require("library.configuration")
 -- These parameters can be changed with a config.txt file
 
 local config = {
-    left_dynamic_cushion = 9,                   -- space between a dynamic and a hairpin on the left
-    right_dynamic_cushion = -9,                 -- space between a dynamic and a haripin on the right
+    left_dynamic_cushion = 9,                   -- space between a dynamic and a hairpin on the left (evpu)
+    right_dynamic_cushion = -9,                 -- space between a dynamic and a haripin on the right (evpu)
     left_selection_cushion = 0,                 -- currently not used
-    right_selection_cushion = 0,                -- additional space between a hairpin and the end of its beat region
+    right_selection_cushion = 0,                -- additional space between a hairpin and the end of its beat region (evpu)
     extend_to_end_of_right_entry = true,        -- if true, extend hairpins through the end of their right note entries
     limit_to_hairpins_on_notes = true,          -- if true, only hairpins attached to notes are considered
     vertical_adjustment_type = "far",           -- possible values: "near", "far", "none"
-    horizontal_adjustment_type = "both"         -- possible values: "both", "left", "right", "none"
+    horizontal_adjustment_type = "both",        -- possible values: "both", "left", "right", "none"
+    vertical_displacement_for_hairpins = 12     -- alignment displacement for hairpins relative to dynamics handle (evpu)
 }
 
 configuration.get_parameters("standalone_hairpin_adjustment.config.txt", config)
@@ -93,7 +94,7 @@ function vertical_dynamic_adjustment(region, direction)
             has_hairpins = true
             local success, staff_offset = smartshape_calc_relative_vertical_position(smart_shape)
             if success then 
-                table.insert(lowest_item, staff_offset)
+                table.insert(lowest_item, staff_offset - config.vertical_displacement_for_hairpins)
             end
         end
     end
@@ -142,7 +143,7 @@ function vertical_dynamic_adjustment(region, direction)
                 min_lowest_position = -160
             else
                 local below_note_cushion = 45
-                min_lowest_position = (staff_pos[1] * 12) - below_note_cushion
+                min_lowest_position = (staff_pos[1] * 12) - below_note_cushion -- multiply by 12 to convert staff position to evpu
             end
             if lowest_item[1] > min_lowest_position then
                 lowest_item[1] = min_lowest_position
@@ -167,11 +168,11 @@ function vertical_dynamic_adjustment(region, direction)
                     end
                     if has_dynamics then
                         if direction == "far" then
-                            left_seg:SetEndpointOffsetY((current_pos - difference_pos) + 12)
-                            right_seg:SetEndpointOffsetY((current_pos - difference_pos) + 12)
+                            left_seg:SetEndpointOffsetY((current_pos - difference_pos) + config.vertical_displacement_for_hairpins)
+                            right_seg:SetEndpointOffsetY((current_pos - difference_pos) + config.vertical_displacement_for_hairpins)
                         else
-                            left_seg:SetEndpointOffsetY((current_pos + difference_pos) + 12)
-                            right_seg:SetEndpointOffsetY((current_pos + difference_pos) + 12)
+                            left_seg:SetEndpointOffsetY((current_pos + difference_pos) + config.vertical_displacement_for_hairpins)
+                            right_seg:SetEndpointOffsetY((current_pos + difference_pos) + config.vertical_displacement_for_hairpins)
                         end
                     else
                         if "far" == direction then


### PR DESCRIPTION
This version adds more options and fixes a few more bugs.
As part of this PR I also added strings to the types of data you can use in library.configuraion. (Both double-quote and single-quote strings.)
Beyond a few bug fixes, the default options leave the script behavior unchanged.