### PR TITLE
Rgp/notehead delete duplicates mmrest adj

### DIFF
--- a/library/enigma_string.lua
+++ b/library/enigma_string.lua
@@ -108,4 +108,9 @@ function enigma_string.remove_inserts (fcstring, replace_with_generic)
     fcstring.LuaString = lua_string
 end
 
+function enigma_string.expand_value_tag(fcstring, value_num)
+    value_num = math.floor(value_num +0.5)
+    fcstring.LuaString = fcstring.LuaString:gsub("%^value%(%)", tostring(value_num)) -- in case value_num is not an integer
+end
+
 return enigma_string

--- a/library/general_library.lua
+++ b/library/general_library.lua
@@ -72,7 +72,7 @@ end
 function library.get_selected_region_or_whole_doc()
     local sel_region = finenv.Region()
     if sel_region:IsEmpty() then
-        sel_region:SetFullDocument()
+        sel_region:SetFullDocument() -- side-effect warning: this also changes finenv.Region() to full doc
     end
     return sel_region
 end
@@ -134,5 +134,15 @@ function library.is_default_measure_number_visible_on_cell (meas_num_region, cel
     return false
 end
 
+-- from_page: page to update from (optional) 1 if omitted
+-- unfreeze_measures: (optional) false if omitted
+function library.update_layout(from_page, unfreeze_measures)
+    from_page = from_page or 1
+    unfreeze_measures = unfreeze_measures or false
+    local page = finale.FCPage()
+    if page:Load(from_page) then
+        page:UpdateLayout(unfreeze_measures)
+    end
+end
 
 return library

--- a/mmrest_widen_to_tempo_mark.lua
+++ b/mmrest_widen_to_tempo_mark.lua
@@ -1,0 +1,82 @@
+function plugindef()
+   -- This function and the 'finaleplugin' namespace
+   -- are both reserved for the plug-in definition.
+    finaleplugin.RequireSelection = false
+    finaleplugin.Author = "Robert Patterson"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "March 8, 2021"
+    finaleplugin.CategoryTags = "Multimeasure Rest"
+    return "Widen Multimeasure Rests to Tempo Mark", "Widen Multimeasure Rests to Tempo Mark", "Widens any multimeasure rest with a tempo mark to be wide enough for the mark."
+end
+
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local library = require("library.general_library")
+local configuration = require("library.configuration")
+
+local config = {
+    additional_padding = 48         -- amount to add to mmrest length, beyond the width of the tempo mark (evpus)
+}
+
+configuration.get_parameters("mmrest_widen_to_tempo_mark.config.txt", config)
+
+function get_expression_offset(exp, cell)
+    local mm = finale.FCCellMetrics()
+    if not mm:LoadAtCell(cell) then
+        finenv.UI():AlertInfo("met failed, m: " .. tostring(cell.Measure) .. " s: " .. tostring(cell.Staff) , "get_expression_offset")
+        return 0
+    end
+    local point = finale.FCPoint(0, 0)
+    if not exp:CalcMetricPos(point) then
+        finenv.UI():AlertInfo("calc failed but got muspos: " .. tostring(mm.MusicStartPos), "get_expression_offset")
+        return 0
+    end
+    local retval = mm.MusicStartPos - point.X   -- ToDo: mm.MusicStartPos may need to be scaled. we'll see.
+    finenv.UI():AlertInfo("muspos: " .. tostring(mm.MusicStartPos) .. " x: " .. tostring(point.X) .. " diff: " .. tostring(retval), "get_expression_offset")
+    mm:FreeMetrics()
+    return retval
+end
+
+function mmrest_widen_to_tempo_mark()
+    local measures = finale.FCMeasures()
+    local sel_region = library.get_selected_region_or_whole_doc()
+    measures:LoadRegion(sel_region)
+    for meas in each(measures) do
+        local mmrest = finale.FCMultiMeasureRest()
+        if mmrest:Load(meas.ItemNo) then
+            local expression_assignments = finale.FCExpressions()
+            expression_assignments:LoadAllForItem(meas.ItemNo)
+            local new_width = mmrest.Width
+            local got1 = false
+            for expression_assignment in each(expression_assignments) do
+                if not expression_assignment:IsShape() then
+                    local expression_def = finale.FCTextExpressionDef()
+                    if expression_def:Load(expression_assignment.ID) then
+                        if finale.DEFAULTCATID_TEMPOMARKS == expression_def.CategoryID then
+                            local text_met = finale.FCTextMetrics()
+                            local fcstring = expression_def:CreateTextString()
+                            local font_info = fcstring:CreateLastFontInfo()
+                            fcstring:TrimEnigmaTags()
+                            text_met:LoadString(fcstring, font_info, 100)
+                            local cell = finale.FCCell(meas.ItemNo, sel_region.StartStaff)
+                            local this_width = text_met:GetAdvanceWidthEVPUs() + config.additional_padding + get_expression_offset(expression_assignment, cell)
+                            if this_width > new_width then
+                                got1 = true
+                                new_width = this_width
+                            end
+                        end
+                    end
+                end
+            end
+            if got1 then
+                mmrest.Width = new_width
+                mmrest:Save()
+            end
+        end
+    end
+    library.update_layout()
+end
+
+mmrest_widen_to_tempo_mark()

--- a/mmrest_widen_to_tempo_mark.lua
+++ b/mmrest_widen_to_tempo_mark.lua
@@ -15,19 +15,20 @@ path:SetRunningLuaFolderPath()
 package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local library = require("library.general_library")
 local configuration = require("library.configuration")
+local enigma_string = require("library.enigma_string")
 
 local config = {
-    additional_padding = 48         -- amount to add to mmrest length, beyond the width of the tempo mark (evpus)
+    additional_padding = 0         -- amount to add to (or subtract from) mmrest length, beyond the width of the tempo mark (evpus)
 }
 
 configuration.get_parameters("mmrest_widen_to_tempo_mark.config.txt", config)
 
--- NOTE: Due to a limitation in either Finale or the PDK Framework, it is not possible to
+-- NOTE: Due to a limitation somewhere in either Finale or the PDK Framework, it is not possible to
 --          use CalcMetricPos for expressions assigned to top or bottom staff. Therefore,
---          this function produces best result when the exp is assigned to the individual staves
+--          this function produces best results when the expression is assigned to the individual staves
 --          in the parts, rather than just Top Staff or Bottom Staff. However, it works
 --          decently well without the get_expression_offset calculation for Top Staff and Bottom Staff
---          assignments. Therefore, you will see an effort in this code to go either way.
+--          assignments, hence the effort in this code to go either way.
 
 function get_expression_offset(exp, cell)
     local mm = finale.FCCellMetrics()
@@ -64,6 +65,7 @@ function mmrest_widen_to_tempo_mark()
                             local text_met = finale.FCTextMetrics()
                             local fcstring = expression_def:CreateTextString()
                             local font_info = fcstring:CreateLastFontInfo()
+                            enigma_string.expand_value_tag(fcstring, expression_def:GetPlaybackTempoValue())
                             fcstring:TrimEnigmaTags()
                             text_met:LoadString(fcstring, font_info, 100)
                             local this_width = text_met:CalcWidthEVPUs() + config.additional_padding

--- a/notehead_delete_duplicates.lua
+++ b/notehead_delete_duplicates.lua
@@ -1,0 +1,41 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Robert Patterson"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "March 8, 2021"
+    finaleplugin.CategoryTags = "Note"
+    return "Delete Duplicate Noteheads", "Delete Duplicate Noteheads", "Removes duplicate noteheads from chords and adjusts ties as needed."
+end
+
+-- This script was a request from the Facebook Finale Powerusers group.
+-- I believe it is mainly useful for cleaning up after a MIDI file import.
+
+function notehead_delete_duplicates()
+    for entry in eachentrysaved(finenv.Region()) do
+        local note_list = {}
+        for note in each(entry) do
+            local pitch = bit32.bor(note.RaiseLower, bit32.lshift(note.Displacement, 16))
+            if nil == note_list[pitch] then
+                note_list[pitch] = note
+            else
+                if note.Tie then
+                    note_list[pitch].Tie = true
+                end
+                if note.TieBackwards then
+                    note_list[pitch].TieBackwards = true
+                end
+                if note.AccidentalFreeze then
+                    note_list[pitch].AccidentalFreeze = true
+                    note_list[pitch].Accidental = note.AccidentalFreeze
+                    if note.AccidentalParentheses then
+                        note_list[pitch].AccidentalParentheses = true
+                    end
+                end
+                entry:DeleteNote(note)
+            end
+        end
+    end    
+end
+
+notehead_delete_duplicates()


### PR DESCRIPTION
This PR adds two new scripts. One that removes duplicate notes from a chord and another that lengthens multimeasure rests to allow horizontal room for tempo markings.