### PR TITLE
Rgp/automatic jete

### DIFF
--- a/library/articulation.lua
+++ b/library/articulation.lua
@@ -2,6 +2,8 @@
 -- Simply import this file to another Lua script to use any of these scripts
 local articulation = {}
 
+local note_entry = require("library.note_entry")
+
 function articulation.delete_from_entry_by_char_num(entry, char_num)
     local artics = entry:CreateArticulations()
     for a in eachbackwards(artics) do
@@ -10,6 +12,31 @@ function articulation.delete_from_entry_by_char_num(entry, char_num)
             a:DeleteData()
         end
     end
+end
+
+-- curr_pos is optional
+function articulation.is_note_side(artic, curr_pos)
+    if nil == curr_pos then
+        curr_pos = finale.FCPoint(0, 0)
+        if not artic:CalcMetricPos(curr_pos) then
+            return false
+        end
+    end
+    local entry = artic:GetNoteEntry()
+    local cell_metrics = finale.FCCell(entry.Measure, entry.Staff):CreateCellMetrics()
+    if nil == cell_metrics then
+        return false
+    end
+    if entry:CalcStemUp() then
+        local bot_pos = note_entry.get_bottom_note_position(entry)
+        bot_pos = math.floor(((10000*bot_pos)/cell_metrics.StaffScaling) + 0.5)
+        return curr_pos.Y <= bot_pos
+    else
+        local top_pos = note_entry.get_top_note_position(entry)
+        top_pos = math.floor(((10000*top_pos)/cell_metrics.StaffScaling) + 0.5)
+        return curr_pos.Y >= top_pos
+    end
+    return false
 end
 
 return articulation

--- a/library/note_entry.lua
+++ b/library/note_entry.lua
@@ -166,4 +166,19 @@ function note_entry.calc_right_of_all_noteheads(entry)
     return right
 end
 
+-- this function assumes for note in each(note_entry) always iterates in the same direction
+-- (Knowing how the Finale PDK works, it probably iterates from bottom to top note.)
+-- currently the PDK Framework does not seem to offer a better option
+-- note_index is zero-based
+function note_entry.calc_note_at_index(entry, note_index)
+    local x = 0
+    for note in each(entry) do
+        if x == note_index then
+            return note
+        end
+        x = x + 1
+    end
+    return nil
+end
+
 return note_entry

--- a/library/note_entry.lua
+++ b/library/note_entry.lua
@@ -42,9 +42,7 @@ function note_entry.get_evpu_notehead_height(entry)
     return evpu_height
 end
 
--- This function may not be used, though it has been tested and works.
--- If you use this function, remove this comment.
--- If you remove this function, be sure to check that it still isn't used.
+-- entry_metrics is an optional parameter
 function note_entry.get_top_note_position(entry, entry_metrics)
     local retval = -math.huge
     local loaded_here = false
@@ -69,9 +67,7 @@ function note_entry.get_top_note_position(entry, entry_metrics)
     return retval
 end
 
--- This function may not be used, though it has been tested and works.
--- If you use this function, remove this comment.
--- If you remove this function, be sure to check that it still isn't used.
+-- entry_metrics is an optional parameter
 function note_entry.get_bottom_note_position(entry, entry_metrics)
     local retval = math.huge
     local loaded_here = false
@@ -179,6 +175,16 @@ function note_entry.calc_note_at_index(entry, note_index)
         x = x + 1
     end
     return nil
+end
+
+-- returns 1 if upstem, -1 otherwise
+-- this is useful for many x,y positioning fields in Finale that mirror +/-
+-- based on stem direction
+function note_entry.stem_sign(entry)
+    if entry:CalcStemUp() then
+        return 1
+    end
+    return -1
 end
 
 return note_entry

--- a/note_automatic_jete.lua
+++ b/note_automatic_jete.lua
@@ -174,7 +174,8 @@ function note_automatic_jete()
                                 if (nil ~= artic) and artic:CalcMetricPos(arg_point) then
                                     local new_y = linear_multplier*arg_point.X + linear_constant -- apply linear equation
                                     local old_vpos = artic.VerticalPos
-                                    artic.VerticalPos = artic.VerticalPos + (math.floor(new_y + 0.5) - arg_point.Y)                                    artic:Save()
+                                    artic.VerticalPos = artic.VerticalPos + (math.floor(new_y + 0.5) - arg_point.Y)
+                                    artic:Save()
                                 end
                             end
                         end

--- a/note_automatic_jete.lua
+++ b/note_automatic_jete.lua
@@ -15,6 +15,23 @@ package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local note_entry = require("library.note_entry")
 
 function add_gliss_line_if_needed(start_note, end_note)
+    -- search for existing
+    local smartshapeentrymarks = finale.FCSmartShapeEntryMarks(start_note.Entry)
+    smartshapeentrymarks:LoadAll()
+    for ssem in each(smartshapeentrymarks) do
+        if ssem:CalcLeftMark() then
+            local ss = finale.FCSmartShape()
+            if ss:Load(ssem.ShapeNumber) then
+                if (ss.ShapeType == finale.SMARTSHAPE_TABSLIDE) then
+                    local rightseg = ss:GetTerminateSegmentRight()
+                    if (rightseg.EntryNumber == end_note.Entry.EntryNumber) and (rightseg.NoteID == end_note.NoteID) then
+                        return ss -- return the found smart shape, in case caller needs it
+                    end
+                end
+            end
+        end
+    end
+    -- not found, so create new
     local smartshape = finale.FCSmartShape()
     smartshape.ShapeType = finale.SMARTSHAPE_TABSLIDE
     smartshape.EntryBased = true

--- a/note_automatic_jete.lua
+++ b/note_automatic_jete.lua
@@ -15,12 +15,15 @@ local path = finale.FCString()
 path:SetRunningLuaFolderPath()
 package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local note_entry = require("library.note_entry")
+local configuration = require("library.configuration")
 
 local max_layers = 4            -- this should be in the PDK, but for some reason isn't
 
 local config = {
     dot_character = 46          -- ascii code for "."
 }
+
+configuration.get_parameters("note_automatic_jete.config.txt", config)
 
 function add_gliss_line_if_needed(start_note, end_note)
     -- search for existing
@@ -30,7 +33,7 @@ function add_gliss_line_if_needed(start_note, end_note)
         if ssem:CalcLeftMark() then
             local ss = finale.FCSmartShape()
             if ss:Load(ssem.ShapeNumber) then
-                if ss:IsTabSlide() then --(ss.ShapeType == finale.SMARTSHAPE_TABSLIDE) then
+                if ss:IsTabSlide() then
                     local rightseg = ss:GetTerminateSegmentRight()
                     if (rightseg.EntryNumber == end_note.Entry.EntryNumber) and (rightseg.NoteID == end_note.NoteID) then
                         return ss -- return the found smart shape, in case caller needs it
@@ -159,7 +162,6 @@ function note_automatic_jete()
                     end
                 end
                 -- shift dot articulations, if any
-                --finenv.UI():AlertInfo("l: (" .. tostring(lpoint.X) .. "," .. tostring(lpoint.Y) .. ") r: (" .. tostring(rpoint.X) .. "," .. tostring(rpoint.Y) .. ")", "show points")
                 if lpoint.X ~= rpoint.X then -- prevent divide-by-zero, but it should not happen if we're here
                     local linear_multplier = (rpoint.Y - lpoint.Y) / (rpoint.X - lpoint.X)
                     local linear_constant = (rpoint.X*lpoint.Y - lpoint.X*rpoint.Y) / (rpoint.X - lpoint.X)
@@ -172,9 +174,7 @@ function note_automatic_jete()
                                 if (nil ~= artic) and artic:CalcMetricPos(arg_point) then
                                     local new_y = linear_multplier*arg_point.X + linear_constant -- apply linear equation
                                     local old_vpos = artic.VerticalPos
-                                    artic.VerticalPos = artic.VerticalPos + (math.floor(new_y + 0.5) - arg_point.Y)
-                                    --finenv.UI():AlertInfo("old/new vpos: (" .. tostring(old_vpos) .. "," .. tostring(artic.VerticalPos) .. ") old/new y ("  .. tostring(arg_point.Y) .. "," .. tostring(new_y) .. ")", "info")
-                                    artic:Save()
+                                    artic.VerticalPos = artic.VerticalPos + (math.floor(new_y + 0.5) - arg_point.Y)                                    artic:Save()
                                 end
                             end
                         end

--- a/note_automatic_jete.lua
+++ b/note_automatic_jete.lua
@@ -1,0 +1,102 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Robert Patterson"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "March 14, 2020"
+    finaleplugin.CategoryTags = "Note"
+    return "Automatic Jeté", "Automatic Jete", -- JW Lua has trouble with non-ascii chars in the Undo string, so eliminate accent on "é"
+           "Add gliss. marks, hide noteheads, and adjust staccato marks as needed for jeté bowing."
+end
+
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local note_entry = require("library.note_entry")
+
+function add_gliss_line_if_needed(start_note, end_note)
+    local smartshape = finale.FCSmartShape()
+    smartshape.ShapeType = finale.SMARTSHAPE_TABSLIDE
+    smartshape.EntryBased = true
+    smartshape.BeatAttached= false
+    smartshape.MakeHorizontal = false
+    smartshape.PresetShape = true
+    smartshape.Visible = true
+    smartshape:SetSlurFlags( false )
+    smartshape:SetEntryAttachedFlags( true )
+    local leftseg = smartshape:GetTerminateSegmentLeft()
+    leftseg.Measure = start_note.Entry.Measure
+    leftseg.Staff = start_note.Entry.Staff
+    leftseg:SetEntry(start_note.Entry)
+    leftseg:SetNoteID(start_note.NoteID)
+    local rightseg = smartshape:GetTerminateSegmentRight()
+    rightseg.Measure = end_note.Entry.Measure
+    rightseg.Staff = end_note.Entry.Staff
+    rightseg:SetEntry(end_note.Entry)
+    rightseg:SetNoteID(end_note.NoteID)
+    if smartshape:SaveNewEverything(start_note.Entry, end_note.Entry) then
+        return smartshape
+    end
+    return nil
+end
+
+function note_automatic_jete()
+    local sel_region = finenv.Region() -- total selected region
+    for slot = sel_region.StartSlot, sel_region.EndSlot do
+        -- get selected region for this staff
+        local staff_region = finale.FCMusicRegion()
+        staff_region:SetCurrentSelection()
+        staff_region.StartSlot = slot
+        staff_region.EndSlot = slot
+        -- find first and last slots
+        local first_entry_num = nil
+        local last_entry_num = nil
+        for entry in eachentry(staff_region) do
+            local is_rest = entry:IsRest()
+            -- break on rests, but only if we've found a non-rest
+            if is_rest and (nil ~= first_entry_num) then
+                break
+            end
+            if not is_rest then
+                if nil == first_entry_num then
+                    first_entry_num = entry.EntryNumber
+                end
+                last_entry_num = entry.EntryNumber
+            end
+        end
+        if first_entry_num ~= last_entry_num then
+            for entry in eachentrysaved(staff_region) do
+                if entry.EntryNumber == first_entry_num then
+                    local last_entry = entry
+                    while (nil ~= last_entry) and (last_entry.EntryNumber ~= last_entry_num) do
+                        last_entry = last_entry:Next()
+                    end
+                    if nil ~= last_entry then
+                        local x = 0
+                        for note in each(entry) do
+                            local last_note = note_entry.calc_note_at_index(last_entry, x)
+                            if nil ~= note then
+                                add_gliss_line_if_needed(note, last_note)
+                            end
+                            x = x + 1
+                        end
+                    end
+                elseif entry.EntryNumber ~= last_entry_num then
+                    entry.LedgerLines = false
+                    entry:SetAccidentals(false)
+                    for note in each(entry) do
+                        note.Accidental = false
+                        note.AccidentalFreeze = true
+                        local nm = finale.FCNoteheadMod()
+                        nm:SetNoteEntry(entry)
+                        nm:LoadAt(note)
+                        nm.CustomChar = string.byte(" ")
+                        nm:SaveAt(note)
+                    end
+                end
+            end
+        end
+    end
+end
+
+note_automatic_jete()

--- a/note_automatic_jete.lua
+++ b/note_automatic_jete.lua
@@ -5,14 +5,22 @@ function plugindef()
     finaleplugin.Version = "1.0"
     finaleplugin.Date = "March 14, 2020"
     finaleplugin.CategoryTags = "Note"
-    return "Automatic Jeté", "Automatic Jete", -- JW Lua has trouble with non-ascii chars in the Undo string, so eliminate accent on "é"
+    return "Automatic Jeté", "Automatic Jete", -- JW Lua has trouble with non-ascii chars in the Undo string, so eliminate the accent on "é" for Undo
            "Add gliss. marks, hide noteheads, and adjust staccato marks as needed for jeté bowing."
 end
+
+-- The goal of this script is to automate jeté bowing notation as given in Gould, Elaine, "Behind Bars", p. 404
 
 local path = finale.FCString()
 path:SetRunningLuaFolderPath()
 package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local note_entry = require("library.note_entry")
+
+local max_layers = 4            -- this should be in the PDK, but for some reason isn't
+
+local config = {
+    dot_character = 46          -- ascii code for "."
+}
 
 function add_gliss_line_if_needed(start_note, end_note)
     -- search for existing
@@ -22,7 +30,7 @@ function add_gliss_line_if_needed(start_note, end_note)
         if ssem:CalcLeftMark() then
             local ss = finale.FCSmartShape()
             if ss:Load(ssem.ShapeNumber) then
-                if (ss.ShapeType == finale.SMARTSHAPE_TABSLIDE) then
+                if ss:IsTabSlide() then --(ss.ShapeType == finale.SMARTSHAPE_TABSLIDE) then
                     local rightseg = ss:GetTerminateSegmentRight()
                     if (rightseg.EntryNumber == end_note.Entry.EntryNumber) and (rightseg.NoteID == end_note.NoteID) then
                         return ss -- return the found smart shape, in case caller needs it
@@ -39,8 +47,8 @@ function add_gliss_line_if_needed(start_note, end_note)
     smartshape.MakeHorizontal = false
     smartshape.PresetShape = true
     smartshape.Visible = true
-    smartshape:SetSlurFlags( false )
-    smartshape:SetEntryAttachedFlags( true )
+    smartshape:SetSlurFlags(false)
+    smartshape:SetEntryAttachedFlags(true)
     local leftseg = smartshape:GetTerminateSegmentLeft()
     leftseg.Measure = start_note.Entry.Measure
     leftseg.Staff = start_note.Entry.Staff
@@ -57,6 +65,24 @@ function add_gliss_line_if_needed(start_note, end_note)
     return nil
 end
 
+function find_staccato_articulation(entry, by_def_id)
+    by_def_id = by_def_id or 0
+    local artics = entry:CreateArticulations()
+    for artic in each(artics) do
+        if by_def_id == artic.ID then
+            return artic
+        elseif 0 == by_def_id then
+            local artic_def = artic:CreateArticulationDef()
+            if nil ~= artic_def then
+                if config.dot_character == artic_def.MainSymbolChar then
+                    return artic
+                end
+            end
+        end
+    end
+    return nil
+end
+
 function note_automatic_jete()
     local sel_region = finenv.Region() -- total selected region
     for slot = sel_region.StartSlot, sel_region.EndSlot do
@@ -65,50 +91,93 @@ function note_automatic_jete()
         staff_region:SetCurrentSelection()
         staff_region.StartSlot = slot
         staff_region.EndSlot = slot
-        -- find first and last slots
-        local first_entry_num = nil
-        local last_entry_num = nil
-        for entry in eachentry(staff_region) do
-            local is_rest = entry:IsRest()
-            -- break on rests, but only if we've found a non-rest
-            if is_rest and (nil ~= first_entry_num) then
-                break
-            end
-            if not is_rest then
-                if nil == first_entry_num then
-                    first_entry_num = entry.EntryNumber
-                end
-                last_entry_num = entry.EntryNumber
-            end
-        end
-        if first_entry_num ~= last_entry_num then
-            for entry in eachentrysaved(staff_region) do
-                if entry.EntryNumber == first_entry_num then
-                    local last_entry = entry
-                    while (nil ~= last_entry) and (last_entry.EntryNumber ~= last_entry_num) do
-                        last_entry = last_entry:Next()
+        for layer = 1, max_layers do
+            -- find first and last entries
+            local first_entry_num = nil
+            local last_entry_num = nil
+            for entry in eachentry(staff_region) do
+                if entry.LayerNumber == layer then
+                    local is_rest = entry:IsRest()
+                    -- break on rests, but only if we've found a non-rest
+                    if is_rest and (nil ~= first_entry_num) then
+                        break
                     end
-                    if nil ~= last_entry then
-                        local x = 0
-                        for note in each(entry) do
-                            local last_note = note_entry.calc_note_at_index(last_entry, x)
-                            if nil ~= note then
-                                add_gliss_line_if_needed(note, last_note)
+                    if not is_rest then
+                        if nil == first_entry_num then
+                            first_entry_num = entry.EntryNumber
+                        end
+                        last_entry_num = entry.EntryNumber
+                    end
+                end
+            end
+            if first_entry_num ~= last_entry_num then
+                local lpoint = nil
+                local rpoint = nil
+                local dot_artic_def = 0
+                for entry in eachentrysaved(staff_region) do
+                    if entry.LayerNumber == layer then
+                        if entry.EntryNumber == first_entry_num then
+                            local last_entry = entry
+                            while (nil ~= last_entry) and (last_entry.EntryNumber ~= last_entry_num) do
+                                last_entry = last_entry:Next()
                             end
-                            x = x + 1
+                            if nil ~= last_entry then
+                                local x = 0
+                                for note in each(entry) do
+                                    local last_note = note_entry.calc_note_at_index(last_entry, x)
+                                    if nil ~= note then
+                                        add_gliss_line_if_needed(note, last_note)
+                                    end
+                                    x = x + 1
+                                end
+                                -- get first and last points for artic defs
+                                local lartic = find_staccato_articulation(entry)
+                                local larg_point = finale.FCPoint(0, 0)
+                                if (nil ~= lartic) and lartic:CalcMetricPos(larg_point) then
+                                    lpoint = larg_point
+                                    dot_artic_def = lartic.ID
+                                    local rartic = find_staccato_articulation(last_entry, dot_artic_def)
+                                    local rarg_point = finale.FCPoint(0, 0)
+                                    if (nil ~= rartic) and rartic:CalcMetricPos(rarg_point) then
+                                        rpoint = rarg_point
+                                    end
+                                end
+                            end
+                        elseif entry.EntryNumber ~= last_entry_num then
+                            entry.LedgerLines = false
+                            entry:SetAccidentals(false)
+                            for note in each(entry) do
+                                note.Accidental = false
+                                note.AccidentalFreeze = true
+                                local nm = finale.FCNoteheadMod()
+                                nm:SetNoteEntry(entry)
+                                nm:LoadAt(note)
+                                nm.CustomChar = string.byte(" ")
+                                nm:SaveAt(note)
+                            end
                         end
                     end
-                elseif entry.EntryNumber ~= last_entry_num then
-                    entry.LedgerLines = false
-                    entry:SetAccidentals(false)
-                    for note in each(entry) do
-                        note.Accidental = false
-                        note.AccidentalFreeze = true
-                        local nm = finale.FCNoteheadMod()
-                        nm:SetNoteEntry(entry)
-                        nm:LoadAt(note)
-                        nm.CustomChar = string.byte(" ")
-                        nm:SaveAt(note)
+                end
+                -- shift dot articulations, if any
+                --finenv.UI():AlertInfo("l: (" .. tostring(lpoint.X) .. "," .. tostring(lpoint.Y) .. ") r: (" .. tostring(rpoint.X) .. "," .. tostring(rpoint.Y) .. ")", "show points")
+                if lpoint.X ~= rpoint.X then -- prevent divide-by-zero, but it should not happen if we're here
+                    local linear_multplier = (rpoint.Y - lpoint.Y) / (rpoint.X - lpoint.X)
+                    local linear_constant = (rpoint.X*lpoint.Y - lpoint.X*rpoint.Y) / (rpoint.X - lpoint.X)
+                    finale.FCNoteEntry.MarkEntryMetricsForUpdate()
+                    for entry in eachentry(staff_region) do
+                        if entry.LayerNumber == layer then
+                            if (entry.EntryNumber ~= first_entry_num) and (entry.EntryNumber ~= last_entry_num) then
+                                local artic = find_staccato_articulation(entry, dot_artic_def)
+                                local arg_point = finale.FCPoint(0, 0)
+                                if (nil ~= artic) and artic:CalcMetricPos(arg_point) then
+                                    local new_y = linear_multplier*arg_point.X + linear_constant -- apply linear equation
+                                    local old_vpos = artic.VerticalPos
+                                    artic.VerticalPos = artic.VerticalPos + (math.floor(new_y + 0.5) - arg_point.Y)
+                                    --finenv.UI():AlertInfo("old/new vpos: (" .. tostring(old_vpos) .. "," .. tostring(artic.VerticalPos) .. ") old/new y ("  .. tostring(arg_point.Y) .. "," .. tostring(new_y) .. ")", "info")
+                                    artic:Save()
+                                end
+                            end
+                        end
                     end
                 end
             end


### PR DESCRIPTION
This script implements automatic jeté notation as given on page 404 of Elaine Gould, "Behind Bars".

I ended up using a couple of the "unused" functions in note_entry.lua, so I changed the comments accordingly.