### PR TITLE
Rgp/transposition rewrite

### DIFF
--- a/library/configuration.lua
+++ b/library/configuration.lua
@@ -11,7 +11,13 @@
 --
 -- <parameter-name> = <parameter-value>
 --
--- Parameter values must be numbers or booleans or strings.
+-- Parameter values may be:
+--      Strings delimited with either single- or double-quotes)
+--      Tables delimited with {}
+--      Booleans (true or false)
+--      Integers
+--
+-- Currently tables embedded within tables is not supported.
 
 local configuration = {}
 
@@ -33,6 +39,32 @@ local strip_leading_trailing_whitespace = function (str)
     return str:match("^%s*(.-)%s*$") -- lua pattern magic taken from the Internet
 end
 
+local parse_parameter -- forward function declaration
+
+local parse_table = function(val_string)
+    local ret_table = {}
+    for element in val_string:gmatch('[^,%s]+') do  -- lua pattern magic taken from the Internet
+        local parsed_element = parse_parameter(element)
+        table.insert(ret_table, parsed_element)
+    end
+    return ret_table
+end
+
+parse_parameter = function(val_string)
+    if '"' == val_string:sub(1,1) and '"' == val_string:sub(#val_string,#val_string) then -- double-quote string
+        return string.gsub(val_string, '"(.+)"', "%1") -- lua pattern magic: "(.+)" matches all characters between two double-quote marks (no escape chars)
+    elseif "'" == val_string:sub(1,1) and "'" == val_string:sub(#val_string,#val_string) then -- single-quote string
+        return string.gsub(val_string, "'(.+)'", "%1") -- lua pattern magic: '(.+)' matches all characters between two single-quote marks (no escape chars)
+    elseif "{" == val_string:sub(1,1) and "}" == val_string:sub(#val_string,#val_string) then
+        return parse_table(string.gsub(val_string, "{(.+)}", "%1"))
+    elseif "true" == val_string then
+        return true
+    elseif "false" == val_string then
+        return false
+    end
+    return tonumber(val_string)
+end
+
 local get_parameters_from_file = function(file_name)
     local parameters = {}
 
@@ -52,17 +84,7 @@ local get_parameters_from_file = function(file_name)
         if nil ~= delimiter_at then
             local name = strip_leading_trailing_whitespace(string.sub(line, 1, delimiter_at-1))
             local val_string = strip_leading_trailing_whitespace(string.sub(line, delimiter_at+1))
-            if '"' == val_string:sub(1,1) and '"' == val_string:sub(#val_string,#val_string) then -- double-quote string
-                parameters[name] = string.gsub(val_string, '"(.+)"', "%1") -- lua pattern magic: "(.+)" matches all characters between two double-quote marks (no escape chars)
-            elseif "'" == val_string:sub(1,1) and "'" == val_string:sub(#val_string,#val_string) then -- single-quote string
-                parameters[name] = string.gsub(val_string, "'(.+)'", "%1") -- lua pattern magic: '(.+)' matches all characters between two single-quote marks (no escape chars)
-            elseif "true" == val_string then
-                parameters[name] = true
-            elseif "false" == val_string then
-                parameters[name] = false
-            else
-                parameters[name] = tonumber(val_string)
-            end
+            parameters[name] = parse_parameter(val_string)
         end
     end
     

--- a/library/transposition.lua
+++ b/library/transposition.lua
@@ -10,37 +10,130 @@
 -- 
 local transposition = {}
 
+local standard_key_number_of_steps          = 12
+local standard_key_major_diatonic_steps     = { 0, 2, 4, 5, 7, 9, 11 }
+local standard_key_minor_diatonic_steps     = { 0, 2, 3, 5, 7, 8, 10 }
+
+--first number is plus_fifths
+--second number is minus_octaves
+local diatonic_interval_adjustments         = { {0,0}, {2,-1}, {4,-2}, {-1,1}, {1,0}, {3,-1}, {5,-2}, {0,1} }
+
+local config = {
+    custom_key_sig_number_of_steps          = standard_key_number_of_steps,
+    custom_key_sig_diatonic_steps           = standard_key_major_diatonic_steps
+}
+
 -- 
 -- HELPER functions
 -- 
 
-function transposition.calc_pitch_string(note)
-    local pitch_string = finale.FCString()
-    local entry = note:GetEntry()
-    local measure = entry:GetMeasure()
-    measure_object = finale.FCMeasure()
-    measure_object:Load(measure)
-    local key_signature = measure_object:GetKeySignature()
-    note:GetString(pitch_string, key_signature, false, false)
-    return pitch_string
+local sign = function(n)
+    if n < 0 then
+        return -1
+    end
+    return 1
 end
 
-function transposition.set_pitch_string(note, pitch_string)
-    local entry = note:GetEntry()
-    local measure = entry:GetMeasure()
-    measure_object = finale.FCMeasure()
-    measure_object:Load(measure)
-    local key_signature = measure_object:GetKeySignature()
-    note:SetString(pitch_string, key_signature, false)
+local signed_modulus = function(n, d)
+    return sign(n) * (math.abs(n) % d)
 end
 
-function transposition.pitch_string_change_octave(pitch_string, n)
-    pitch_string.LuaString = pitch_string.LuaString:sub(1, -2) .. (tonumber(string.sub(pitch_string.LuaString, -1)) + n)
-    return pitch_string
+local get_key_signature = function(note)
+    local cell = finale.FCCell(note.Entry.Measure, note.Entry.Staff)
+    return cell:GetKeySignature()
+end
+
+-- return number of steps, diatonic steps, root index, and number of diatonic steps in fifth
+local get_key_info = function(key)
+    local number_of_steps = standard_key_number_of_steps
+    local diatonic_steps = standard_key_major_diatonic_steps
+    local root_index = key:CalcScaleRootIndex()
+    if not key:IsPredefined() then
+        number_of_steps = config.custom_key_sig_number_of_steps
+        diatonic_steps = config.custom_key_sig_diatonic_steps
+    elseif key:IsMinor() then
+        diatonic_steps = standard_key_minor_diatonic_steps
+    end
+    -- 0.5849625 is log(3/2)/log(2), which is how to calculate the 5th per Ere Lievonen.
+    -- For standard key sigs (and most others) this calculation comes out to 5
+    local fifth_steps = math.floor((number_of_steps*0.5849625) + 0.5) 
+    return number_of_steps, diatonic_steps, root_index, fifth_steps
+end
+
+local calc_scale_degree = function(interval, number_of_diatonic_steps_in_key)
+    local interval_normalized = signed_modulus(interval, number_of_diatonic_steps_in_key)
+    if interval_normalized < 0 then
+        interval_normalized = interval_normalized + number_of_diatonic_steps_in_key
+    end
+    return interval_normalized
+end
+
+local calc_steps_between_scale_degrees = function(key, first_disp, second_disp)
+    --finenv.UI():AlertInfo("first note: " .. tostring(first_disp) .. " second note: " .. tostring(second_disp), "calc_steps_between_scale_degrees")
+    local number_of_steps_in_key, diatonic_steps = get_key_info(key)
+    local first_scale_degree = calc_scale_degree(first_disp, #diatonic_steps)
+    local second_scale_degree = calc_scale_degree(second_disp, #diatonic_steps)
+    local number_of_steps = sign(second_disp - first_disp) * (diatonic_steps[second_scale_degree+1] - diatonic_steps[first_scale_degree+1])
+    --finenv.UI():AlertInfo("first deg: " .. tostring(first_scale_degree) .. " second deg: " .. tostring(second_scale_degree) ..
+    --        " diasteps2: " ..tostring(diatonic_steps[second_scale_degree+1]) .. " diatsteps 1 " .. tostring(diatonic_steps[first_scale_degree+1]) .. 
+    --        " numsteps: " .. tostring(number_of_steps),
+   --         "calc_steps_between_scale_degrees")
+    if number_of_steps < 0 then
+        number_of_steps = number_of_steps + number_of_steps_in_key
+    end
+    return number_of_steps
+end
+
+local calc_steps_in_alteration = function(key, interval, alteration)
+    local number_of_steps_in_key, _, _, fifth_steps = get_key_info(key)
+    local plus_fifths = sign(interval) * alteration * 7 -- number of fifths to add for alteration
+    local minus_octaves = sign(interval) * alteration * -4 -- number of octaves to subtract for alteration
+    local new_alteration = sign(interval) * ((plus_fifths*fifth_steps) + (minus_octaves*number_of_steps_in_key)) -- new alteration for chromatic interval
+    --finenv.UI():AlertInfo("interval " .. tostring(interval) .. " plus_fifths: " .. tostring(plus_fifths) .. " minus oct: " .. tostring(minus_octaves), "info")
+    --finenv.UI():AlertInfo("org alt: " .. tostring(alteration) .. " new alt: " .. tostring(new_alteration), "info")
+    return new_alteration
+end
+
+local calc_steps_in_normalized_interval = function(key, interval_normalized)
+    local number_of_steps_in_key, _, _, fifth_steps = get_key_info(key)
+    local plus_fifths = diatonic_interval_adjustments[math.abs(interval_normalized)+1][1] -- number of fifths to add for interval
+    local minus_octaves = diatonic_interval_adjustments[math.abs(interval_normalized)+1][2] -- number of octaves to subtract for alteration
+    local number_of_steps_in_interval = sign(interval_normalized) * ((plus_fifths*fifth_steps) + (minus_octaves*number_of_steps_in_key))
+    finenv.UI():AlertInfo("interval " .. tostring(interval_normalized) .. " plus_fifths: " .. tostring(plus_fifths) .. " minus oct: " .. tostring(minus_octaves) ..
+                            " 5steps: " .. tostring(fifth_steps) .. " 8vesteps: " .. tostring(number_of_steps_in_key), "calc_steps_in_normalized_interval")
+    return number_of_steps_in_interval
+end
+
+-- 
+-- DIATONIC transposition (affect only Displacement)
+-- 
+
+function transposition.diatonic_transpose(note, interval)
+    note.Displacement = note.Displacement + interval
 end
 
 function transposition.change_octave(note, n)
-    note.Displacement = note.Displacement + 7*n
+    transposition.diatonic_transpose(note, 7*n)
+end
+
+-- 
+-- CHROMATIC transposition (affect Displacement and RaiseLower)
+-- 
+
+function transposition.chromatic_transpose(note, interval, alteration)
+    local key = get_key_signature(note)
+    local number_of_steps, diatonic_steps, root_index, fifth_steps = get_key_info(key)
+    local interval_normalized = signed_modulus(interval, #diatonic_steps)
+    finenv.UI():AlertInfo("int: " .. tostring(interval) .. " int norm: " .. tostring(interval_normalized), "transposition.chromatic_transpose")
+    local steps_in_alteration = calc_steps_in_alteration(key, interval, alteration)
+    local steps_in_interval = calc_steps_in_normalized_interval(key, interval_normalized)
+    local steps_in_diatonic_interval = calc_steps_between_scale_degrees(key, note.Displacement, note.Displacement + interval_normalized)
+    local effective_alteration = steps_in_alteration + steps_in_interval - sign(interval)*steps_in_diatonic_interval
+    finenv.UI():AlertInfo("step alt: " .. tostring(steps_in_alteration) .. " steps int: " .. tostring(steps_in_interval) ..
+                            " steps diat: " .. tostring(steps_in_diatonic_interval) .. " eff alt: " .. tostring(effective_alteration), "transposition.chromatic_transpose")
+
+    transposition.diatonic_transpose(note, interval)
+    note.RaiseLower = note.RaiseLower + effective_alteration
 end
 
 function transposition.set_notes_to_same_pitch(note_a, note_b)
@@ -48,30 +141,11 @@ function transposition.set_notes_to_same_pitch(note_a, note_b)
     note_b.RaiseLower = note_a.RaiseLower
 end
 
-
--- 
--- DIATONIC transposition
--- 
-
-function transposition.diatonic_third_down(note)
-    note.Displacement = note.Displacement - 2
-end
-
-function transposition.diatonic_fourth_up(note)
-    note.Displacement = note.Displacement + 3
-end
-
-function transposition.diatonic_fifth_down(note)
-    note.Displacement = note.Displacement + 4
-end
-
--- 
--- CHROMATIC transposition
--- 
-
 function transposition.chromatic_major_third_down(note)
+    transposition.chromatic_transpose(note, -2, -0)
+    --[[
     local original_midi_key = note:CalcMIDIKey()
-    transposition.diatonic_third_down(note)
+    transposition.diatonic_transpose(note, -2)
 
     -- fixes any errors from the diatonic transposition
     if (note:CalcMIDIKey() - original_midi_key ~= 4) then
@@ -79,11 +153,12 @@ function transposition.chromatic_major_third_down(note)
         print(note:CalcMIDIKey() - original_midi_key + 4)
         note.RaiseLower = note.RaiseLower - error
     end
-end
+    ]]
+end 
 
 function transposition.chromatic_perfect_fourth_up(note)
     local original_midi_key = note:CalcMIDIKey()
-    transposition.diatonic_fourth_up(note)
+    transposition.diatonic_transpose(note, 3)
 
     -- fixes any errors from the diatonic transposition
     if (note:CalcMIDIKey() - original_midi_key ~= 5) then
@@ -94,7 +169,7 @@ end
 
 function transposition.chromatic_perfect_fifth_down(note)
     local original_midi_key = note:CalcMIDIKey()
-    transposition.diatonic_fifth_down(note)
+    transposition.diatonic_transpose(note, -4)
 
     -- fixes any errors from the diatonic transposition
     if (note:CalcMIDIKey() - original_midi_key ~= 7) then

--- a/library/transposition.lua
+++ b/library/transposition.lua
@@ -10,6 +10,8 @@
 -- 
 local transposition = {}
 
+local configuration = require("library.configuration")
+
 local standard_key_number_of_steps          = 12
 local standard_key_major_diatonic_steps     = { 0, 2, 4, 5, 7, 9, 11 }
 local standard_key_minor_diatonic_steps     = { 0, 2, 3, 5, 7, 8, 10 }
@@ -18,10 +20,12 @@ local standard_key_minor_diatonic_steps     = { 0, 2, 3, 5, 7, 8, 10 }
 --second number is minus_octaves
 local diatonic_interval_adjustments         = { {0,0}, {2,-1}, {4,-2}, {-1,1}, {1,0}, {3,-1}, {5,-2}, {0,1} }
 
-local config = {
-    custom_key_sig_number_of_steps          = standard_key_number_of_steps,
-    custom_key_sig_diatonic_steps           = standard_key_major_diatonic_steps
+local custom_key_sig_config = {
+    number_of_steps                         = standard_key_number_of_steps,
+    diatonic_steps                          = standard_key_major_diatonic_steps
 }
+
+configuration.get_parameters("custom_key_sig.config.txt", custom_key_sig_config)
 
 -- 
 -- HELPER functions
@@ -45,8 +49,8 @@ local get_key_info = function(key)
     local number_of_steps = standard_key_number_of_steps
     local diatonic_steps = standard_key_major_diatonic_steps
     if not key:IsPredefined() then
-        number_of_steps = config.custom_key_sig_number_of_steps
-        diatonic_steps = config.custom_key_sig_diatonic_steps
+        number_of_steps = custom_key_sig_config.number_of_steps
+        diatonic_steps = custom_key_sig_config.diatonic_steps
     elseif key:IsMinor() then
         diatonic_steps = standard_key_minor_diatonic_steps
     end

--- a/library/transposition.lua
+++ b/library/transposition.lua
@@ -40,11 +40,6 @@ local signed_modulus = function(n, d)
     return sign(n) * (math.abs(n) % d)
 end
 
-local get_key_signature = function(note)
-    local cell = finale.FCCell(note.Entry.Measure, note.Entry.Staff)
-    return cell:GetKeySignature()
-end
-
 -- return number of steps, diatonic steps map, and number of steps in fifth
 local get_key_info = function(key)
     local number_of_steps = standard_key_number_of_steps
@@ -113,7 +108,8 @@ end
 -- 
 
 function transposition.chromatic_transpose(note, interval, alteration)
-    local key = get_key_signature(note)
+    local cell = finale.FCCell(note.Entry.Measure, note.Entry.Staff)
+    local key = cell:GetKeySignature()
     local number_of_steps, diatonic_steps, fifth_steps = get_key_info(key)
     local interval_normalized = signed_modulus(interval, #diatonic_steps)
     local steps_in_alteration = calc_steps_in_alteration(key, interval, alteration)

--- a/library/transposition.lua
+++ b/library/transposition.lua
@@ -40,60 +40,29 @@ function transposition.pitch_string_change_octave(pitch_string, n)
 end
 
 function transposition.change_octave(note, n)
-    local pitch_string = transposition.calc_pitch_string(note)
-    pitch_string = transposition.pitch_string_change_octave(pitch_string, n)
-    transposition.set_pitch_string(note, pitch_string)
+    note.Displacement = note.Displacement + 7*n
 end
 
 function transposition.set_notes_to_same_pitch(note_a, note_b)
-    local pitch_string = transposition.calc_pitch_string(note_a)
-    transposition.set_pitch_string(note_b, pitch_string)
+    note_b.Displacement = note_a.Displacement
+    note_b.RaiseLower = note_a.RaiseLower
 end
+
 
 -- 
 -- DIATONIC transposition
 -- 
 
 function transposition.diatonic_third_down(note)
-    local pitch_string = transposition.calc_pitch_string(note)
-    local letters = "ABCDEFGABCDEFG"
-    local note_name_position = letters:find(pitch_string.LuaString:sub(1, 1))
-    local new_note = letters:sub(note_name_position + 5, note_name_position + 5)
-    pitch_string.LuaString = new_note .. pitch_string.LuaString:sub(2)
-
-    -- transposes everything an octave higher if necessary
-    if (note_name_position < 5) and note_name_position > 2 then
-        pitch_string = transposition.pitch_string_change_octave(pitch_string, -1)
-    end
-    transposition.set_pitch_string(note, pitch_string)
+    note.Displacement = note.Displacement - 2
 end
 
 function transposition.diatonic_fourth_up(note)
-    local pitch_string = transposition.calc_pitch_string(note)
-    local letters = "ABCDEFGABCDEFG"
-    local note_name_position = letters:find(pitch_string.LuaString:sub(1, 1))
-    local new_note = letters:sub(note_name_position + 3, note_name_position + 3)
-    pitch_string.LuaString = new_note .. pitch_string.LuaString:sub(2)
-
-    -- transposes everything an octave higher if necessary
-    if (note_name_position >= 7) or note_name_position <= 2 then
-        pitch_string = transposition.pitch_string_change_octave(pitch_string, 1)
-    end
-    transposition.set_pitch_string(note, pitch_string)
+    note.Displacement = note.Displacement + 3
 end
 
 function transposition.diatonic_fifth_down(note)
-    local pitch_string = transposition.calc_pitch_string(note)
-    local letters = "ABCDEFGABCDEFG"
-    local note_name_position = letters:find(pitch_string.LuaString:sub(1, 1))
-    local new_note = letters:sub(note_name_position + 3, note_name_position + 3)
-    pitch_string.LuaString = new_note .. pitch_string.LuaString:sub(2)
-
-    -- transposes everything an octave higher if necessary
-    if (note_name_position < 7) and note_name_position > 2 then
-        pitch_string = transposition.pitch_string_change_octave(pitch_string, -1)
-    end
-    transposition.set_pitch_string(note, pitch_string)
+    note.Displacement = note.Displacement + 4
 end
 
 -- 

--- a/standalone_hairpin_adjustment.lua
+++ b/standalone_hairpin_adjustment.lua
@@ -137,7 +137,7 @@ function vertical_dynamic_adjustment(region, direction)
 
         table.sort(staff_pos)
 
-        if (nil ~= staff_pos[1]) and ("far" == direction) then
+        if (nil ~= staff_pos[1]) and ("far" == direction) and (#lowest_item > 0) then
             local min_lowest_position = lowest_item[1]
             if staff_pos[1] > -7 then
                 min_lowest_position = -160


### PR DESCRIPTION
I have gone ahead and implemented math-based transposition in the transposition library. This pull request is fully backwards compatible with the previous note-name-based transposition. However, it also fixes at least one bug I found in the old transposition. In C Major, transposing F up a perfect fourth resulted in B# rather than Bb. The new version correctly produces Bb.

I envision further enhancements to

- Provide an option to simply the note spelling
- Attempt to compensate if the alteration exceeds +/- 7. (This issue is quite common in larger EDO microtonal systems.)

I also intend to provide a U.I. front end. It will be mainly useful for users of microtonal key signatures, but it will include a simplified spelling option and a U.I. to transpose arbitrarily by number of steps with simplified spelling. (For standard key signatures this means by number of half steps.) Some of this should be of interest to users of standard key sigs as well.
