### PR TITLE
Bug Fixes and Configs

### DIFF
--- a/library/note_entry.lua
+++ b/library/note_entry.lua
@@ -199,4 +199,15 @@ function note_entry.duplicate_note(note)
     return new_note
 end
 
+function note_entry.spans_number_of_octaves(entry)
+    local top_note = entry:CalcHighestNote(nil)
+    local bottom_note = entry:CalcLowestNote(nil)
+    local displacement_diff = top_note.Displacement - bottom_note.Displacement
+    local num_octaves = math.floor(displacement_diff / 7)
+    if 0 ~= (displacement_diff % 7) then
+        num_octaves = num_octaves + 1
+    end
+    return num_octaves
+end
+
 return note_entry

--- a/library/note_entry.lua
+++ b/library/note_entry.lua
@@ -199,14 +199,17 @@ function note_entry.duplicate_note(note)
     return new_note
 end
 
-function note_entry.spans_number_of_octaves(entry)
+--[[
+    NoteEntry: note_entry.calc_spans_number_of_octaves(entry)
+    Calculates the numer of octaves spanned by a chord (considering only staff positions, not accidentals)
+    @ entry (FCNoteEntry) the entry to calculate from
+    : number of octaves spanned
+]]
+function note_entry.calc_spans_number_of_octaves(entry)
     local top_note = entry:CalcHighestNote(nil)
     local bottom_note = entry:CalcLowestNote(nil)
     local displacement_diff = top_note.Displacement - bottom_note.Displacement
-    local num_octaves = math.floor(displacement_diff / 7)
-    if 0 ~= (displacement_diff % 7) then
-        num_octaves = num_octaves + 1
-    end
+    local num_octaves = math.ceil(displacement_diff / 7)
     return num_octaves
 end
 

--- a/library/notehead.lua
+++ b/library/notehead.lua
@@ -2,21 +2,47 @@
 -- Simply import this file to another Lua script to use any of these scripts
 local notehead = {}
 
+local config = {
+    diamond_open                = 79,
+    diamond_closed              = 79,   -- per Elaine Gould, use open diamond even on closed regular notes, but allow it to be overridden
+    diamond_resize              = 110,
+    diamond_whole_offset        = 5,
+    diamond_breve_offset        = 14
+}
+
+-- use this func because CalcStemUp is not reliable for wholes or breves
+-- also it's not reliable after transposition
+local calc_stem_up = function(note)
+    if note.Entry.FreezeStem then
+        return note.Entry:CalcStemUp()
+    end
+    return (note:CalcStaffPosition() < -5) -- this works a lot of the time, and when it doesn't the user can use free-stem to make it right
+end
+
 function notehead.change_shape(note, shape)
     local notehead = finale.FCNoteheadMod()
     notehead:EraseAt(newnote)
 
     if shape == "diamond" then
-        notehead.CustomChar = 79
-        notehead.Resize = 110
         local entry = note:GetEntry()
-        if (entry:GetDuration() == 4096) then
-            if (note:CalcStaffPosition() >= -5) then
-                notehead.HorizontalPos = 5
+        local offset = 0
+        local notehead_char = config.diamond_open
+        if entry.Duration >= finale.BREVE then
+            offset = config.diamond_breve_offset
+        elseif entry.Duration >= finale.WHOLE_NOTE then
+            offset = config.diamond_whole_offset
+        elseif entry.Duration < finale.HALF_NOTE then
+            notehead_char = config.diamond_closed
+        end
+        if (0 ~= offset) then
+            if calc_stem_up(note) then
+                notehead.HorizontalPos = -1*offset
             else
-                notehead.HorizontalPos = -5
+                notehead.HorizontalPos = offset
             end
         end
+        notehead.CustomChar = notehead_char
+        notehead.Resize = config.diamond_resize
     end
 
     notehead:SaveAt(note)

--- a/library/notehead.lua
+++ b/library/notehead.lua
@@ -2,6 +2,8 @@
 -- Simply import this file to another Lua script to use any of these scripts
 local notehead = {}
 
+local configuration = require("library.configuration")
+
 local config = {
     diamond_open                = 79,
     diamond_closed              = 79,   -- per Elaine Gould, use open diamond even on closed regular notes, but allow it to be overridden
@@ -10,14 +12,7 @@ local config = {
     diamond_breve_offset        = 14
 }
 
--- use this func because CalcStemUp is not reliable for wholes or breves
--- also it's not reliable after transposition
-local calc_stem_up = function(note)
-    if note.Entry.FreezeStem then
-        return note.Entry:CalcStemUp()
-    end
-    return (note:CalcStaffPosition() < -5) -- this works a lot of the time, and when it doesn't the user can use free-stem to make it right
-end
+configuration.get_parameters("notehead.config.txt", config)
 
 function notehead.change_shape(note, shape)
     local notehead = finale.FCNoteheadMod()
@@ -35,7 +30,7 @@ function notehead.change_shape(note, shape)
             notehead_char = config.diamond_closed
         end
         if (0 ~= offset) then
-            if calc_stem_up(note) then
+            if entry:CalcStemUp() then
                 notehead.HorizontalPos = -1*offset
             else
                 notehead.HorizontalPos = offset

--- a/pitch_entry_double_octave_down.lua
+++ b/pitch_entry_double_octave_down.lua
@@ -2,8 +2,8 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Nick Mazuk"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0.1"
-    finaleplugin.Date = "June 12, 2020"
+    finaleplugin.Version = "1.0.2"
+    finaleplugin.Date = "March 31, 2021"
     finaleplugin.CategoryTags = "Pitch"
     finaleplugin.AuthorURL = "https://nickmazuk.com"
     return "Octave Doubling Down", "Octave Doubling Down", "Doubles the current note an octave lower"
@@ -17,10 +17,17 @@ local note_entry = require("Library.note_entry")
 
 function pitch_entry_double_octave_down()
     for entry in eachentrysaved(finenv.Region()) do
-        if (entry.Count == 1) then
-            local note = entry:CalcLowestNote(nil)
+        local note_count = entry.Count
+        local note_index = 0
+        for note in each(entry) do
+            note_index = note_index + 1
+            if note_index > note_count then
+                break
+            end
             local new_note = note_entry.duplicate_note(note)
-            transposition.change_octave(new_note, -1)
+            if nil ~= new_note then
+                transposition.change_octave(new_note, -1)
+            end
         end
     end
 end

--- a/pitch_entry_double_octave_up.lua
+++ b/pitch_entry_double_octave_up.lua
@@ -2,8 +2,8 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Nick Mazuk"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0.1"
-    finaleplugin.Date = "June 12, 2020"
+    finaleplugin.Version = "1.0.2"
+    finaleplugin.Date = "March 31, 2021"
     finaleplugin.CategoryTags = "Pitch"
     finaleplugin.AuthorURL = "https://nickmazuk.com"
     return "Octave Doubling Up", "Octave Doubling Up", "Doubles the current note an octave higher"
@@ -17,10 +17,17 @@ local note_entry = require("Library.note_entry")
 
 function pitch_entry_double_octave_up()
     for entry in eachentrysaved(finenv.Region()) do
-        if (entry.Count == 1) then
-            local note = entry:CalcLowestNote(nil)
+        local note_count = entry.Count
+        local note_index = 0
+        for note in each(entry) do
+            note_index = note_index + 1
+            if note_index > note_count then
+                break
+            end
             local new_note = note_entry.duplicate_note(note)
-            transposition.change_octave(new_note, 1)
+            if nil ~= new_note then
+                transposition.change_octave(new_note, 1)
+            end
         end
     end
 end

--- a/pitch_rotate_chord_down.lua
+++ b/pitch_rotate_chord_down.lua
@@ -19,7 +19,7 @@ local note_entry = require("library.note_entry")
 function pitch_rotate_chord_up()
     for entry in eachentrysaved(finenv.Region()) do
         if (entry.Count >= 2) then
-            local num_octaves = note_entry.spans_number_of_octaves(entry)
+            local num_octaves = note_entry.calc_spans_number_of_octaves(entry)
             local top_note = entry:CalcHighestNote(nil)
             transposition.change_octave(top_note, -1*math.max(1,num_octaves))
         end

--- a/pitch_rotate_chord_down.lua
+++ b/pitch_rotate_chord_down.lua
@@ -21,7 +21,15 @@ function pitch_rotate_chord_up()
         if (entry.Count >= 2) then
             local num_octaves = note_entry.calc_spans_number_of_octaves(entry)
             local top_note = entry:CalcHighestNote(nil)
+            local bottom_note = entry:CalcLowestNote(nil)
             transposition.change_octave(top_note, -1*math.max(1,num_octaves))
+            --octave-spanning chords (such as common 4-note piano chords) need some special attention
+            if top_note:IsIdenticalPitch(bottom_note) and (entry.Count > 2) then
+                local new_top_note = entry:CalcHighestNote(nil)
+                top_note.Displacement = new_top_note.Displacement
+                top_note.RaiseLower = new_top_note.RaiseLower
+                transposition.change_octave(top_note, -1*math.max(1,num_octaves))
+            end
         end
     end
 end

--- a/pitch_rotate_chord_down.lua
+++ b/pitch_rotate_chord_down.lua
@@ -2,8 +2,8 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Nick Mazuk"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0"
-    finaleplugin.Date = "June 20, 2020"
+    finaleplugin.Version = "1.0.1"
+    finaleplugin.Date = "March 30, 2021"
     finaleplugin.CategoryTags = "Pitch"
     finaleplugin.AuthorURL = "https://nickmazuk.com"
     return "Rotate Chord Down", "Rotate Chord Down",
@@ -14,16 +14,14 @@ local path = finale.FCString()
 path:SetRunningLuaFolderPath()
 package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local transposition = require("library.transposition")
+local note_entry = require("library.note_entry")
 
 function pitch_rotate_chord_up()
     for entry in eachentrysaved(finenv.Region()) do
         if (entry.Count >= 2) then
+            local num_octaves = note_entry.spans_number_of_octaves(entry)
             local top_note = entry:CalcHighestNote(nil)
-            local bottom_note = entry:CalcLowestNote(nil)
-
-            while top_note:CalcMIDIKey() > bottom_note:CalcMIDIKey() do
-                transposition.change_octave(top_note, -1)
-            end
+            transposition.change_octave(top_note, -1*math.max(1,num_octaves))
         end
     end
 end

--- a/pitch_rotate_chord_up.lua
+++ b/pitch_rotate_chord_up.lua
@@ -19,7 +19,7 @@ local note_entry = require("library.note_entry")
 function pitch_rotate_chord_up()
     for entry in eachentrysaved(finenv.Region()) do
         if (entry.Count >= 2) then
-            local num_octaves = note_entry.spans_number_of_octaves(entry)
+            local num_octaves = note_entry.calc_spans_number_of_octaves(entry)
             local bottom_note = entry:CalcLowestNote(nil)
             transposition.change_octave(bottom_note, math.max(1,num_octaves))
         end

--- a/pitch_rotate_chord_up.lua
+++ b/pitch_rotate_chord_up.lua
@@ -20,8 +20,16 @@ function pitch_rotate_chord_up()
     for entry in eachentrysaved(finenv.Region()) do
         if (entry.Count >= 2) then
             local num_octaves = note_entry.calc_spans_number_of_octaves(entry)
+            local top_note = entry:CalcHighestNote(nil)
             local bottom_note = entry:CalcLowestNote(nil)
             transposition.change_octave(bottom_note, math.max(1,num_octaves))
+            --octave-spanning chords (such as common 4-note piano chords) need some special attention
+            if top_note:IsIdenticalPitch(bottom_note) and (entry.Count > 2) then
+                local new_bottom_note = entry:CalcLowestNote(nil)
+                bottom_note.Displacement = new_bottom_note.Displacement
+                bottom_note.RaiseLower = new_bottom_note.RaiseLower
+                transposition.change_octave(bottom_note, math.max(1,num_octaves))
+            end
         end
     end
 end

--- a/pitch_rotate_chord_up.lua
+++ b/pitch_rotate_chord_up.lua
@@ -2,8 +2,8 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Nick Mazuk"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0"
-    finaleplugin.Date = "June 20, 2020"
+    finaleplugin.Version = "1.0.1"
+    finaleplugin.Date = "March 30, 2021"
     finaleplugin.CategoryTags = "Pitch"
     finaleplugin.AuthorURL = "https://nickmazuk.com"
     return "Rotate Chord Up", "Rotate Chord Up",
@@ -14,16 +14,14 @@ local path = finale.FCString()
 path:SetRunningLuaFolderPath()
 package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local transposition = require("library.transposition")
+local note_entry = require("library.note_entry")
 
 function pitch_rotate_chord_up()
     for entry in eachentrysaved(finenv.Region()) do
         if (entry.Count >= 2) then
-            local top_note = entry:CalcHighestNote(nil)
+            local num_octaves = note_entry.spans_number_of_octaves(entry)
             local bottom_note = entry:CalcLowestNote(nil)
-
-            while top_note:CalcMIDIKey() > bottom_note:CalcMIDIKey() do
-                transposition.change_octave(bottom_note, 1)
-            end
+            transposition.change_octave(bottom_note, math.max(1,num_octaves))
         end
     end
 end

--- a/pitch_transform_harmonics_fifth.lua
+++ b/pitch_transform_harmonics_fifth.lua
@@ -2,8 +2,8 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Nick Mazuk"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0"
-    finaleplugin.Date = "June 15, 2020"
+    finaleplugin.Version = "1.0.1"
+    finaleplugin.Date = "March 30, 2021"
     finaleplugin.CategoryTags = "Pitch"
     finaleplugin.AuthorURL = "https://nickmazuk.com"
     return "String Harmonics 5th - Sounding Pitch", "String Harmonics 5th - Sounding Pitch",

--- a/pitch_transform_harmonics_fifth.lua
+++ b/pitch_transform_harmonics_fifth.lua
@@ -20,15 +20,19 @@ local note_entry = require("Library.note_entry")
 
 function pitch_transform_harmonics_fifth()
     for entry in eachentrysaved(finenv.Region()) do
-        if (entry.Count == 1) then
+        if (entry.Count == 1) and (not entry:IsRest()) then
             articulation.delete_from_entry_by_char_num(entry, 111)
             local note = entry:CalcLowestNote(nil)
             transposition.change_octave(note, -1)
-
             local new_note = note_entry.duplicate_note(note)
-
             transposition.chromatic_perfect_fifth_down(new_note)
-
+        end
+    end
+    -- we have to change the note shapes in a separate pass because we may need to get the stem direction
+    -- after transposition, which means the entry has to be saved first
+    for entry in eachentrysaved(finenv.Region()) do
+        if (entry.Count == 2) then
+            local note = entry:CalcHighestNote(nil)
             notehead.change_shape(note, "diamond")
         end
     end

--- a/pitch_transform_harmonics_fourth.lua
+++ b/pitch_transform_harmonics_fourth.lua
@@ -2,8 +2,8 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Nick Mazuk"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0"
-    finaleplugin.Date = "June 15, 2020"
+    finaleplugin.Version = "1.0.1"
+    finaleplugin.Date = "March 30, 2021"
     finaleplugin.CategoryTags = "Pitch"
     finaleplugin.AuthorURL = "https://nickmazuk.com"
     return "String Harmonics 4th - Sounding Pitch", "String Harmonics 4th - Sounding Pitch",

--- a/pitch_transform_harmonics_fourth.lua
+++ b/pitch_transform_harmonics_fourth.lua
@@ -20,16 +20,20 @@ local note_entry = require("Library.note_entry")
 
 function pitch_transform_harmonics_fourth()
     for entry in eachentrysaved(finenv.Region()) do
-        if (entry.Count == 1) then
+        if (entry.Count == 1) and (not entry:IsRest()) then
             articulation.delete_from_entry_by_char_num(entry, 111)
             local note = entry:CalcLowestNote(nil)
             transposition.change_octave(note, -2)
-
             local new_note = note_entry.duplicate_note(note)
-
             transposition.chromatic_perfect_fourth_up(new_note)
-
-            notehead.change_shape(new_note, "diamond")
+        end
+    end
+    -- we have to change the note shapes in a separate pass because we may need to get the stem direction
+    -- after transposition, which means the entry has to be saved first
+    for entry in eachentrysaved(finenv.Region()) do
+        if (entry.Count == 2) then
+            local note = entry:CalcHighestNote(nil)
+            notehead.change_shape(note, "diamond")
         end
     end
 end

--- a/pitch_transform_harmonics_major_third.lua
+++ b/pitch_transform_harmonics_major_third.lua
@@ -2,8 +2,8 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Nick Mazuk"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0"
-    finaleplugin.Date = "June 15, 2020"
+    finaleplugin.Version = "1.0.1"
+    finaleplugin.Date = "March 30, 2021"
     finaleplugin.CategoryTags = "Pitch"
     finaleplugin.AuthorURL = "https://nickmazuk.com"
     return "String Harmonics M3rd - Sounding Pitch", "String Harmonics M3rd - Sounding Pitch",

--- a/pitch_transform_harmonics_major_third.lua
+++ b/pitch_transform_harmonics_major_third.lua
@@ -20,15 +20,19 @@ local note_entry = require("Library.note_entry")
 
 function pitch_transform_harmonics_major_third()
     for entry in eachentrysaved(finenv.Region()) do
-        if (entry.Count == 1) then
+        if (entry.Count == 1) and (not entry:IsRest()) then
             articulation.delete_from_entry_by_char_num(entry, 111)
             local note = entry:CalcLowestNote(nil)
             transposition.change_octave(note, -2)
-
-            local new_note = note_entry.duplicate_note(note)
-            
+            local new_note = note_entry.duplicate_note(note)            
             transposition.chromatic_major_third_down(new_note)
-
+        end
+    end
+    -- we have to change the note shapes in a separate pass because we may need to get the stem direction
+    -- after transposition, which means the entry has to be saved first
+    for entry in eachentrysaved(finenv.Region()) do
+        if (entry.Count == 2) then
+            local note = entry:CalcHighestNote(nil)
             notehead.change_shape(note, "diamond")
         end
     end

--- a/transpose_chromatic.lua
+++ b/transpose_chromatic.lua
@@ -3,8 +3,8 @@ function plugindef()
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
     finaleplugin.Version = "1.0"
-    finaleplugin.Date = "March 25, 2020"
-    finaleplugin.CategoryTags = "Note"
+    finaleplugin.Date = "March 25, 2021"
+    finaleplugin.CategoryTags = "Pitch"
     return "Transpose Chromatic...", "Transpose Chromatic",
            "Chromatic transposition of selected region (supports microtone systems)."
 end

--- a/transpose_enharmonic_down.lua
+++ b/transpose_enharmonic_down.lua
@@ -3,8 +3,8 @@ function plugindef()
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
     finaleplugin.Version = "1.0"
-    finaleplugin.Date = "March 25, 2020"
-    finaleplugin.CategoryTags = "Note"
+    finaleplugin.Date = "March 25, 2021"
+    finaleplugin.CategoryTags = "Pitch"
     return "Enharmonic Transpose Down", "Enharmonic Transpose Down",
            "Transpose down enharmonically all notes in selected regions."
 end

--- a/transpose_enharmonic_up.lua
+++ b/transpose_enharmonic_up.lua
@@ -3,8 +3,8 @@ function plugindef()
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
     finaleplugin.Version = "1.0"
-    finaleplugin.Date = "March 25, 2020"
-    finaleplugin.CategoryTags = "Note"
+    finaleplugin.Date = "March 25, 2021"
+    finaleplugin.CategoryTags = "Pitch"
     return "Enharmonic Transpose Up", "Enharmonic Transpose Up",
            "Transpose up enharmonically all notes in selected regions."
 end


### PR DESCRIPTION
This pull request incorporates various bug fixes and minor enhancements and code cleanup.

**String Harmonics**
- Add support for breve noteheads.
- Use CalcStemUp instead of CalcStaffPosition to determine direction of offsets for whole and breve noteheads (much more accurate).
- Fixed issue where non-floating rests could cause a runtime error.
- Add config file support for open and closed harmonic noteheads (but default is all-open, per Elaine Gould).
- Add config file support for whole and breve offsets and resize percentage.

**Double Octave Up/Down**
- Now supports chords in addition to single notes.

**Rotate Chords Up/Down**
- Replace MIDI note-based logic with logic that takes into account note spelling.
- Add support for octave spanning chords (such as the extremely common 4-note triad voicings found in keyboard music).

Other minor cleanup.