### PR TITLE
Add automated library documentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "github-actions"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,23 @@
+name: Generate docs
+
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  test-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nick-mazuk/lua-docs-generator@v1
+        with:
+          input: './library'
+          output: './docs/library'
+      - name: Push updated docs
+        run: |
+          git config user.name CI
+          git config user.email "<>"
+          git add .
+          git diff --quiet HEAD || git commit -m "$GITHUB_SHA"
+          git push

--- a/library/articulation.lua
+++ b/library/articulation.lua
@@ -1,5 +1,6 @@
--- A collection of helpful JW Lua articulation scripts
--- Simply import this file to another Lua script to use any of these scripts
+--[[
+$module articulation
+]]
 local articulation = {}
 
 local note_entry = require("library.note_entry")

--- a/library/configuration.lua
+++ b/library/configuration.lua
@@ -1,23 +1,25 @@
--- A collection of helpful JW Lua scripts to retrieve parameters from a text file
--- Simply import this file to another Lua script to use any of these scripts
---
--- Author: Robert Patterson
--- Date: March 5, 2021
---
--- This library implements a text file scheme as follows:
--- Comments start with "--"
--- Leading and trailing whitespace is ignored
--- Each parameter is named and delimited by a colon as follows:
---
--- <parameter-name> = <parameter-value>
---
--- Parameter values may be:
---      Strings delimited with either single- or double-quotes)
---      Tables delimited with {}
---      Booleans (true or false)
---      Integers
---
--- Currently tables embedded within tables is not supported.
+--[[
+$module Configuration
+
+Author: Robert Patterson
+Date: March 5, 2021
+
+This library implements a text file scheme as follows:
+Comments start with "--"
+Leading and trailing whitespace is ignored
+Each parameter is named and delimited by a colon as follows:
+
+<parameter-name> = <parameter-value>
+
+Parameter values may be:
+
+- Strings delimited with either single- or double-quotes)
+- Tables delimited with {}
+- Booleans (true or false)
+- Integers
+
+Currently tables embedded within tables is not supported.
+]]
 
 local configuration = {}
 
@@ -91,9 +93,12 @@ local get_parameters_from_file = function(file_name)
     return parameters
 end
 
--- configuration.get_parameters
--- file_name: the file name of the config file (which will be prepended with the script_settings_dir)
--- parameter_list: a table with the parameter name as key and the default value as value
+--[[
+% get_parameters(file_name, parameter_list)
+
+@ file_name (string) the file name of the config file (which will be prepended with the script_settings_dir)
+@ parameter_list (table) a table with the parameter name as key and the default value as value
+]]
 function configuration.get_parameters(file_name, parameter_list)
     local file_parameters = get_parameters_from_file(script_settings_dir .. path_delimiter .. file_name)
     if nil ~= file_parameters then

--- a/library/enigma_string.lua
+++ b/library/enigma_string.lua
@@ -1,14 +1,15 @@
--- A library of helpful JW Lua scripts for enigma strings
--- Ideally these would be available in the PDK Framework
--- Simply import this file to another Lua script to use any of these scripts
+--[[
+$module Enigma String
+
+This implements a hypothetical FCString::TrimFirstEnigmaFontTags() function that would
+preferably be in the PDK Framework. Trimming only first allows us to preserve
+style changes within the rest of the string, such as changes from plain to
+italic. Ultimately this seems more useful than trimming out all font tags.
+If the PDK Framework is ever changed, it might be even better to create replace font
+functions that can replace only font, only size, only style, or all three together.
+]]
 local enigma_string = {}
 
---This implements a hypothetical FCString::TrimFirstEnigmaFontTags() function that would
---preferably be in the PDK Framework. Trimming only first allows us to preserve
---style changes within the rest of the string, such as changes from plain to
---italic. Ultimately this seems more useful than trimming out all font tags.
---If the PDK Framework is ever changed, it might be even better to create replace font
---functions that can replace only font, only size, only style, or all three together.
 
 local starts_with_font_command = function(string)
     local text_cmds = {"^font", "^Font", "^fontMus", "^fontTxt", "^fontNum", "^size", "^nfx"}
@@ -20,7 +21,12 @@ local starts_with_font_command = function(string)
     return false
 end
 
---returns the first font info that was stripped or nil if none
+--[[
+% trim_first_enigma_font_tags(string)
+
+@ string (string)
+: (string | nill) the first font info that was stripped or nil if none
+]]
 function enigma_string.trim_first_enigma_font_tags(string)
     local font_info = finale.FCFontInfo()
     local found_tag = false

--- a/library/expression.lua
+++ b/library/expression.lua
@@ -1,5 +1,6 @@
--- A collection of helpful JW Lua articulation scripts
--- Simply import this file to another Lua script to use any of these scripts
+--[[
+$module Expression
+]]
 local expression = {}
 
 local library = require("library.general_library")
@@ -63,7 +64,12 @@ function expression.calc_handle_offset_for_smart_shape(exp_assign)
     return (manual_horizontal + def_horizontal + alignment_offset)
 end
 
--- expand_tags is optional (default false) (currently only supports ^value())
+--[[
+% calc_text_width(expression_def, expand_tags)
+
+@ expression_def (FCExpessionDef)
+@ [expand_tags] (boolean) defaults to false, currently only suppoerts `^value()`
+]]
 function expression.calc_text_width(expression_def, expand_tags)
     expand_tags = expand_tags or false
     local fcstring = expression_def:CreateTextString()
@@ -74,7 +80,12 @@ function expression.calc_text_width(expression_def, expand_tags)
     return retval
 end
 
--- current_part is optional
+--[[
+% is_for_current_part(exp_assign, current_part)
+
+@ exp_assign (unknown)
+@ [current_part] (unknown)
+]]
 function expression.is_for_current_part(exp_assign, current_part)
     current_part = current_part or library.get_current_part()
     if current_part:IsScore() and exp_assign.ScoreAssignment then

--- a/library/general_library.lua
+++ b/library/general_library.lua
@@ -1,5 +1,6 @@
--- A library of helpful JW Lua scripts
--- Simply import this file to another Lua script to use any of these scripts
+--[[
+$module Library
+]]
 local library = {}
 
 function library.add_augmentation_dot(entry)
@@ -134,8 +135,12 @@ function library.is_default_measure_number_visible_on_cell (meas_num_region, cel
     return false
 end
 
--- from_page: page to update from (optional) 1 if omitted
--- unfreeze_measures: (optional) false if omitted
+--[[
+% update_layout(from_page, unfreeze_measures)
+
+@ [from_page] (number) page to update from, defaults to 1
+@ [unfreeze_measures] (boolean) defaults to false
+]]
 function library.update_layout(from_page, unfreeze_measures)
     from_page = from_page or 1
     unfreeze_measures = unfreeze_measures or false

--- a/library/note_entry.lua
+++ b/library/note_entry.lua
@@ -1,10 +1,17 @@
--- Helpful JW Lua scripts for note entries
--- Simply import this file to another Lua script to use any of these scripts
+--[[
+$module Note Entry
+]]
 local note_entry = {}
 
 -- This function may not be used, though it has been tested and works.
 -- If you use this function, remove this comment.
 -- If you remove this function, be sure to check that it still isn't used.
+--[[
+% get_music_region(entry)
+
+@ entry (FCNoteEntry)
+: (FCMusicRegion)
+]]
 function note_entry.get_music_region(entry)
     local exp_region = finale.FCMusicRegion()
     exp_region:SetCurrentSelection() -- called to match the selected IU list (e.g., if using Staff Sets)
@@ -35,6 +42,13 @@ end
 -- This function may not be used, though it has been tested and works.
 -- If you use this function, remove this comment.
 -- If you remove this function, be sure to check that it still isn't used.
+--[[
+% get_evpu_notehead_height(entry)
+
+@ entry (FCNoteEntry)
+
+: (number) the EVPU height
+]]
 function note_entry.get_evpu_notehead_height(entry)
     local highest_note = entry:CalcHighestNote(nil)
     local lowest_note = entry:CalcLowestNote(nil)
@@ -42,7 +56,12 @@ function note_entry.get_evpu_notehead_height(entry)
     return evpu_height
 end
 
--- entry_metrics is an optional parameter
+--[[
+% get_top_note_position(entry, entry_metrics)
+
+@ entry (FCNoteEntry)
+@ [entry_metrics] (FCEntryMetrics)
+]]
 function note_entry.get_top_note_position(entry, entry_metrics)
     local retval = -math.huge
     local loaded_here = false
@@ -67,7 +86,12 @@ function note_entry.get_top_note_position(entry, entry_metrics)
     return retval
 end
 
--- entry_metrics is an optional parameter
+--[[
+% get_bottom_note_position(entry, entry_metrics)
+
+@ entry (FCNoteEntry)
+@ [entry_metrics] (FCEntryMetrics)
+]]
 function note_entry.get_bottom_note_position(entry, entry_metrics)
     local retval = math.huge
     local loaded_here = false
@@ -93,6 +117,15 @@ function note_entry.get_bottom_note_position(entry, entry_metrics)
 end
 
 -- return widest left-side notehead width and widest right-side notehead width
+
+--[[
+% calc_widths(entry)
+
+Get the widest left-side notehead width and widest right-side notehead width.
+
+@ entry (FCNoteEntry)
+: (number, number) widest left-side notehead width and widest right-side notehead width
+]]
 function note_entry.calc_widths(entry)
     local left_width = 0
     local right_width = 0
@@ -162,10 +195,16 @@ function note_entry.calc_right_of_all_noteheads(entry)
     return right
 end
 
--- this function assumes for note in each(note_entry) always iterates in the same direction
--- (Knowing how the Finale PDK works, it probably iterates from bottom to top note.)
--- currently the PDK Framework does not seem to offer a better option
--- note_index is zero-based
+--[[
+% calc_note_at_index(entry, note_index)
+
+this function assumes for note in each(note_entry) always iterates in the same direction
+(Knowing how the Finale PDK works, it probably iterates from bottom to top note.)
+currently the PDK Framework does not seem to offer a better option
+
+@ entry (FCNoteEntry)
+@ note_index (number) the zero-based index
+]]
 function note_entry.calc_note_at_index(entry, note_index)
     local x = 0
     for note in each(entry) do
@@ -177,9 +216,15 @@ function note_entry.calc_note_at_index(entry, note_index)
     return nil
 end
 
--- returns 1 if upstem, -1 otherwise
--- this is useful for many x,y positioning fields in Finale that mirror +/-
--- based on stem direction
+--[[
+% stem_sign(entry)
+
+This is useful for many x,y positioning fields in Finale that mirror +/-
+based on stem direction.
+
+@ entry (FCNoteEntry)
+: (number) 1 if upstem, -1 otherwise
+]]
 function note_entry.stem_sign(entry)
     if entry:CalcStemUp() then
         return 1
@@ -187,7 +232,12 @@ function note_entry.stem_sign(entry)
     return -1
 end
 
--- returns reference to added FCNote or nil if not success
+--[[
+% duplicate_note(note)
+
+@ note (FCNote)
+: (FCNote | nil) reference to added FCNote or nil if not success
+]]
 function note_entry.duplicate_note(note)
     local new_note = note.Entry:AddNewNote()
     if nil ~= new_note then
@@ -200,10 +250,12 @@ function note_entry.duplicate_note(note)
 end
 
 --[[
-    NoteEntry: note_entry.calc_spans_number_of_octaves(entry)
-    Calculates the numer of octaves spanned by a chord (considering only staff positions, not accidentals)
-    @ entry (FCNoteEntry) the entry to calculate from
-    : number of octaves spanned
+% calc_spans_number_of_octaves(entry)
+
+Calculates the numer of octaves spanned by a chord (considering only staff positions, not accidentals)
+
+@ entry (FCNoteEntry) the entry to calculate from
+: number of octaves spanned
 ]]
 function note_entry.calc_spans_number_of_octaves(entry)
     local top_note = entry:CalcHighestNote(nil)


### PR DESCRIPTION
This PR does 3 things.

1. Adds a GitHub Action to automatically create documentation for the library scripts on each push to main
2. Adds Dependabot, so a PR will be created each time the GitHub action is updated
3. Converts current documentation comments in the library scripts into ExpLua

And merging this PR into the master branch will start creating the documentation. The docs will be added to `docs/library`. This way we can add more documentation about general development in the repo to hopefully onboard new users (coming tomorrow, hopefully).

Related issue: https://github.com/Nick-Mazuk/jw-lua-scripts/issues/55

Keeping the issue open as there's still more to do.

---

I know we were talking about using [this GitHub Action](https://github.com/marketplace/actions/lua-docs-generator) to create the documentation, however, I could not figure out how to update the Python code to parse ExpLua. And since there were no tests, I wasn't confident that any changes I'd make would result in regressions for current users. So I created a new GitHub action that's used in this PR: https://github.com/marketplace/actions/generate-lua-docs

There are a few, slight differences between this action and the Python-based action. The main differences are that this action assumes "one documentation file per Lua file", and this action parses ExpLua. It's also much better (uhmm…) documented. 

You can see exactly how comments are parsed [here](https://github.com/Nick-Mazuk/lua-docs-generator/blob/main/documentation.md). There are also a few [examples](https://github.com/Nick-Mazuk/lua-docs-generator/tree/main/test-files).

The action is new, but it is tested. If bugs are found, I can easily fix them. And since there are tests for every feature, there should not be regressions.