### PR TITLE
SMuFL font metadata reader that sets engraving defaults based on metadata

### DIFF
--- a/src/lunajson/LICENSE
+++ b/src/lunajson/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2017 Shunsuke Shimizu (grafi)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/lunajson/decoder.lua
+++ b/src/lunajson/decoder.lua
@@ -1,0 +1,515 @@
+local setmetatable, tonumber, tostring =
+      setmetatable, tonumber, tostring
+local floor, inf =
+      math.floor, math.huge
+local mininteger, tointeger =
+      math.mininteger or nil, math.tointeger or nil
+local byte, char, find, gsub, match, sub =
+      string.byte, string.char, string.find, string.gsub, string.match, string.sub
+
+local function _decode_error(pos, errmsg)
+	error("parse error at " .. pos .. ": " .. errmsg, 2)
+end
+
+local f_str_ctrl_pat
+if _VERSION == "Lua 5.1" then
+	-- use the cluttered pattern because lua 5.1 does not handle \0 in a pattern correctly
+	f_str_ctrl_pat = '[^\32-\255]'
+else
+	f_str_ctrl_pat = '[\0-\31]'
+end
+
+local _ENV = nil
+
+
+local function newdecoder()
+	local json, pos, nullv, arraylen, rec_depth
+
+	-- `f` is the temporary for dispatcher[c] and
+	-- the dummy for the first return value of `find`
+	local dispatcher, f
+
+	--[[
+		Helper
+	--]]
+	local function decode_error(errmsg)
+		return _decode_error(pos, errmsg)
+	end
+
+	--[[
+		Invalid
+	--]]
+	local function f_err()
+		decode_error('invalid value')
+	end
+
+	--[[
+		Constants
+	--]]
+	-- null
+	local function f_nul()
+		if sub(json, pos, pos+2) == 'ull' then
+			pos = pos+3
+			return nullv
+		end
+		decode_error('invalid value')
+	end
+
+	-- false
+	local function f_fls()
+		if sub(json, pos, pos+3) == 'alse' then
+			pos = pos+4
+			return false
+		end
+		decode_error('invalid value')
+	end
+
+	-- true
+	local function f_tru()
+		if sub(json, pos, pos+2) == 'rue' then
+			pos = pos+3
+			return true
+		end
+		decode_error('invalid value')
+	end
+
+	--[[
+		Numbers
+		Conceptually, the longest prefix that matches to `[-+.0-9A-Za-z]+` (in regexp)
+		is captured as a number and its conformance to the JSON spec is checked.
+	--]]
+	-- deal with non-standard locales
+	local radixmark = match(tostring(0.5), '[^0-9]')
+	local fixedtonumber = tonumber
+	if radixmark ~= '.' then
+		if find(radixmark, '%W') then
+			radixmark = '%' .. radixmark
+		end
+		fixedtonumber = function(s)
+			return tonumber(gsub(s, '.', radixmark))
+		end
+	end
+
+	local function number_error()
+		return decode_error('invalid number')
+	end
+
+	-- `0(\.[0-9]*)?([eE][+-]?[0-9]*)?`
+	local function f_zro(mns)
+		local num, c = match(json, '^(%.?[0-9]*)([-+.A-Za-z]?)', pos)  -- skipping 0
+
+		if num == '' then
+			if c == '' then
+				if mns then
+					return -0.0
+				end
+				return 0
+			end
+
+			if c == 'e' or c == 'E' then
+				num, c = match(json, '^([^eE]*[eE][-+]?[0-9]+)([-+.A-Za-z]?)', pos)
+				if c == '' then
+					pos = pos + #num
+					if mns then
+						return -0.0
+					end
+					return 0.0
+				end
+			end
+			number_error()
+		end
+
+		if byte(num) ~= 0x2E or byte(num, -1) == 0x2E then
+			number_error()
+		end
+
+		if c ~= '' then
+			if c == 'e' or c == 'E' then
+				num, c = match(json, '^([^eE]*[eE][-+]?[0-9]+)([-+.A-Za-z]?)', pos)
+			end
+			if c ~= '' then
+				number_error()
+			end
+		end
+
+		pos = pos + #num
+		c = fixedtonumber(num)
+
+		if mns then
+			c = -c
+		end
+		return c
+	end
+
+	-- `[1-9][0-9]*(\.[0-9]*)?([eE][+-]?[0-9]*)?`
+	local function f_num(mns)
+		pos = pos-1
+		local num, c = match(json, '^([0-9]+%.?[0-9]*)([-+.A-Za-z]?)', pos)
+		if byte(num, -1) == 0x2E then  -- error if ended with period
+			number_error()
+		end
+
+		if c ~= '' then
+			if c ~= 'e' and c ~= 'E' then
+				number_error()
+			end
+			num, c = match(json, '^([^eE]*[eE][-+]?[0-9]+)([-+.A-Za-z]?)', pos)
+			if not num or c ~= '' then
+				number_error()
+			end
+		end
+
+		pos = pos + #num
+		c = fixedtonumber(num)
+
+		if mns then
+			c = -c
+			if c == mininteger and not find(num, '[^0-9]') then
+				c = mininteger
+			end
+		end
+		return c
+	end
+
+	-- skip minus sign
+	local function f_mns()
+		local c = byte(json, pos)
+		if c then
+			pos = pos+1
+			if c > 0x30 then
+				if c < 0x3A then
+					return f_num(true)
+				end
+			else
+				if c > 0x2F then
+					return f_zro(true)
+				end
+			end
+		end
+		decode_error('invalid number')
+	end
+
+	--[[
+		Strings
+	--]]
+	local f_str_hextbl = {
+		0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
+		0x8, 0x9, inf, inf, inf, inf, inf, inf,
+		inf, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, inf,
+		inf, inf, inf, inf, inf, inf, inf, inf,
+		inf, inf, inf, inf, inf, inf, inf, inf,
+		inf, inf, inf, inf, inf, inf, inf, inf,
+		inf, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF,
+		__index = function()
+			return inf
+		end
+	}
+	setmetatable(f_str_hextbl, f_str_hextbl)
+
+	local f_str_escapetbl = {
+		['"']  = '"',
+		['\\'] = '\\',
+		['/']  = '/',
+		['b']  = '\b',
+		['f']  = '\f',
+		['n']  = '\n',
+		['r']  = '\r',
+		['t']  = '\t',
+		__index = function()
+			decode_error("invalid escape sequence")
+		end
+	}
+	setmetatable(f_str_escapetbl, f_str_escapetbl)
+
+	local function surrogate_first_error()
+		return decode_error("1st surrogate pair byte not continued by 2nd")
+	end
+
+	local f_str_surrogate_prev = 0
+	local function f_str_subst(ch, ucode)
+		if ch == 'u' then
+			local c1, c2, c3, c4, rest = byte(ucode, 1, 5)
+			ucode = f_str_hextbl[c1-47] * 0x1000 +
+			        f_str_hextbl[c2-47] * 0x100 +
+			        f_str_hextbl[c3-47] * 0x10 +
+			        f_str_hextbl[c4-47]
+			if ucode ~= inf then
+				if ucode < 0x80 then  -- 1byte
+					if rest then
+						return char(ucode, rest)
+					end
+					return char(ucode)
+				elseif ucode < 0x800 then  -- 2bytes
+					c1 = floor(ucode / 0x40)
+					c2 = ucode - c1 * 0x40
+					c1 = c1 + 0xC0
+					c2 = c2 + 0x80
+					if rest then
+						return char(c1, c2, rest)
+					end
+					return char(c1, c2)
+				elseif ucode < 0xD800 or 0xE000 <= ucode then  -- 3bytes
+					c1 = floor(ucode / 0x1000)
+					ucode = ucode - c1 * 0x1000
+					c2 = floor(ucode / 0x40)
+					c3 = ucode - c2 * 0x40
+					c1 = c1 + 0xE0
+					c2 = c2 + 0x80
+					c3 = c3 + 0x80
+					if rest then
+						return char(c1, c2, c3, rest)
+					end
+					return char(c1, c2, c3)
+				elseif 0xD800 <= ucode and ucode < 0xDC00 then  -- surrogate pair 1st
+					if f_str_surrogate_prev == 0 then
+						f_str_surrogate_prev = ucode
+						if not rest then
+							return ''
+						end
+						surrogate_first_error()
+					end
+					f_str_surrogate_prev = 0
+					surrogate_first_error()
+				else  -- surrogate pair 2nd
+					if f_str_surrogate_prev ~= 0 then
+						ucode = 0x10000 +
+						        (f_str_surrogate_prev - 0xD800) * 0x400 +
+						        (ucode - 0xDC00)
+						f_str_surrogate_prev = 0
+						c1 = floor(ucode / 0x40000)
+						ucode = ucode - c1 * 0x40000
+						c2 = floor(ucode / 0x1000)
+						ucode = ucode - c2 * 0x1000
+						c3 = floor(ucode / 0x40)
+						c4 = ucode - c3 * 0x40
+						c1 = c1 + 0xF0
+						c2 = c2 + 0x80
+						c3 = c3 + 0x80
+						c4 = c4 + 0x80
+						if rest then
+							return char(c1, c2, c3, c4, rest)
+						end
+						return char(c1, c2, c3, c4)
+					end
+					decode_error("2nd surrogate pair byte appeared without 1st")
+				end
+			end
+			decode_error("invalid unicode codepoint literal")
+		end
+		if f_str_surrogate_prev ~= 0 then
+			f_str_surrogate_prev = 0
+			surrogate_first_error()
+		end
+		return f_str_escapetbl[ch] .. ucode
+	end
+
+	-- caching interpreted keys for speed
+	local f_str_keycache = setmetatable({}, {__mode="v"})
+
+	local function f_str(iskey)
+		local newpos = pos
+		local tmppos, c1, c2
+		repeat
+			newpos = find(json, '"', newpos, true)  -- search '"'
+			if not newpos then
+				decode_error("unterminated string")
+			end
+			tmppos = newpos-1
+			newpos = newpos+1
+			c1, c2 = byte(json, tmppos-1, tmppos)
+			if c2 == 0x5C and c1 == 0x5C then  -- skip preceding '\\'s
+				repeat
+					tmppos = tmppos-2
+					c1, c2 = byte(json, tmppos-1, tmppos)
+				until c2 ~= 0x5C or c1 ~= 0x5C
+				tmppos = newpos-2
+			end
+		until c2 ~= 0x5C  -- leave if '"' is not preceded by '\'
+
+		local str = sub(json, pos, tmppos)
+		pos = newpos
+
+		if iskey then  -- check key cache
+			tmppos = f_str_keycache[str]  -- reuse tmppos for cache key/val
+			if tmppos then
+				return tmppos
+			end
+			tmppos = str
+		end
+
+		if find(str, f_str_ctrl_pat) then
+			decode_error("unescaped control string")
+		end
+		if find(str, '\\', 1, true) then  -- check whether a backslash exists
+			-- We need to grab 4 characters after the escape char,
+			-- for encoding unicode codepoint to UTF-8.
+			-- As we need to ensure that every first surrogate pair byte is
+			-- immediately followed by second one, we grab upto 5 characters and
+			-- check the last for this purpose.
+			str = gsub(str, '\\(.)([^\\]?[^\\]?[^\\]?[^\\]?[^\\]?)', f_str_subst)
+			if f_str_surrogate_prev ~= 0 then
+				f_str_surrogate_prev = 0
+				decode_error("1st surrogate pair byte not continued by 2nd")
+			end
+		end
+		if iskey then  -- commit key cache
+			f_str_keycache[tmppos] = str
+		end
+		return str
+	end
+
+	--[[
+		Arrays, Objects
+	--]]
+	-- array
+	local function f_ary()
+		rec_depth = rec_depth + 1
+		if rec_depth > 1000 then
+			decode_error('too deeply nested json (> 1000)')
+		end
+		local ary = {}
+
+		pos = match(json, '^[ \n\r\t]*()', pos)
+
+		local i = 0
+		if byte(json, pos) == 0x5D then  -- check closing bracket ']' which means the array empty
+			pos = pos+1
+		else
+			local newpos = pos
+			repeat
+				i = i+1
+				f = dispatcher[byte(json,newpos)]  -- parse value
+				pos = newpos+1
+				ary[i] = f()
+				newpos = match(json, '^[ \n\r\t]*,[ \n\r\t]*()', pos)  -- check comma
+			until not newpos
+
+			newpos = match(json, '^[ \n\r\t]*%]()', pos)  -- check closing bracket
+			if not newpos then
+				decode_error("no closing bracket of an array")
+			end
+			pos = newpos
+		end
+
+		if arraylen then -- commit the length of the array if `arraylen` is set
+			ary[0] = i
+		end
+		rec_depth = rec_depth - 1
+		return ary
+	end
+
+	-- objects
+	local function f_obj()
+		rec_depth = rec_depth + 1
+		if rec_depth > 1000 then
+			decode_error('too deeply nested json (> 1000)')
+		end
+		local obj = {}
+
+		pos = match(json, '^[ \n\r\t]*()', pos)
+		if byte(json, pos) == 0x7D then  -- check closing bracket '}' which means the object empty
+			pos = pos+1
+		else
+			local newpos = pos
+
+			repeat
+				if byte(json, newpos) ~= 0x22 then  -- check '"'
+					decode_error("not key")
+				end
+				pos = newpos+1
+				local key = f_str(true)  -- parse key
+
+				-- optimized for compact json
+				-- c1, c2 == ':', <the first char of the value> or
+				-- c1, c2, c3 == ':', ' ', <the first char of the value>
+				f = f_err
+				local c1, c2, c3 = byte(json, pos, pos+3)
+				if c1 == 0x3A then
+					if c2 ~= 0x20 then
+						f = dispatcher[c2]
+						newpos = pos+2
+					else
+						f = dispatcher[c3]
+						newpos = pos+3
+					end
+				end
+				if f == f_err then  -- read a colon and arbitrary number of spaces
+					newpos = match(json, '^[ \n\r\t]*:[ \n\r\t]*()', pos)
+					if not newpos then
+						decode_error("no colon after a key")
+					end
+					f = dispatcher[byte(json, newpos)]
+					newpos = newpos+1
+				end
+				pos = newpos
+				obj[key] = f()  -- parse value
+				newpos = match(json, '^[ \n\r\t]*,[ \n\r\t]*()', pos)
+			until not newpos
+
+			newpos = match(json, '^[ \n\r\t]*}()', pos)
+			if not newpos then
+				decode_error("no closing bracket of an object")
+			end
+			pos = newpos
+		end
+
+		rec_depth = rec_depth - 1
+		return obj
+	end
+
+	--[[
+		The jump table to dispatch a parser for a value,
+		indexed by the code of the value's first char.
+		Nil key means the end of json.
+	--]]
+	dispatcher = { [0] =
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_str, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_mns, f_err, f_err,
+		f_zro, f_num, f_num, f_num, f_num, f_num, f_num, f_num,
+		f_num, f_num, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_ary, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_fls, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_nul, f_err,
+		f_err, f_err, f_err, f_err, f_tru, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_obj, f_err, f_err, f_err, f_err,
+		__index = function()
+			decode_error("unexpected termination")
+		end
+	}
+	setmetatable(dispatcher, dispatcher)
+
+	--[[
+		run decoder
+	--]]
+	local function decode(json_, pos_, nullv_, arraylen_)
+		json, pos, nullv, arraylen = json_, pos_, nullv_, arraylen_
+		rec_depth = 0
+
+		pos = match(json, '^[ \n\r\t]*()', pos)
+
+		f = dispatcher[byte(json, pos)]
+		pos = pos+1
+		local v = f()
+
+		if pos_ then
+			return v, pos
+		else
+			f, pos = find(json, '^[ \n\r\t]*', pos)
+			if pos ~= #json then
+				decode_error('json ended')
+			end
+			return v
+		end
+	end
+
+	return decode
+end
+
+return newdecoder

--- a/src/lunajson/encoder.lua
+++ b/src/lunajson/encoder.lua
@@ -1,0 +1,185 @@
+local error = error
+local byte, find, format, gsub, match = string.byte, string.find, string.format,  string.gsub, string.match
+local concat = table.concat
+local tostring = tostring
+local pairs, type = pairs, type
+local setmetatable = setmetatable
+local huge, tiny = 1/0, -1/0
+
+local f_string_esc_pat
+if _VERSION == "Lua 5.1" then
+	-- use the cluttered pattern because lua 5.1 does not handle \0 in a pattern correctly
+	f_string_esc_pat = '[^ -!#-[%]^-\255]'
+else
+	f_string_esc_pat = '[\0-\31"\\]'
+end
+
+local _ENV = nil
+
+
+local function newencoder()
+	local v, nullv
+	local i, builder, visited
+
+	local function f_tostring(v)
+		builder[i] = tostring(v)
+		i = i+1
+	end
+
+	local radixmark = match(tostring(0.5), '[^0-9]')
+	local delimmark = match(tostring(12345.12345), '[^0-9' .. radixmark .. ']')
+	if radixmark == '.' then
+		radixmark = nil
+	end
+
+	local radixordelim
+	if radixmark or delimmark then
+		radixordelim = true
+		if radixmark and find(radixmark, '%W') then
+			radixmark = '%' .. radixmark
+		end
+		if delimmark and find(delimmark, '%W') then
+			delimmark = '%' .. delimmark
+		end
+	end
+
+	local f_number = function(n)
+		if tiny < n and n < huge then
+			local s = format("%.17g", n)
+			if radixordelim then
+				if delimmark then
+					s = gsub(s, delimmark, '')
+				end
+				if radixmark then
+					s = gsub(s, radixmark, '.')
+				end
+			end
+			builder[i] = s
+			i = i+1
+			return
+		end
+		error('invalid number')
+	end
+
+	local doencode
+
+	local f_string_subst = {
+		['"'] = '\\"',
+		['\\'] = '\\\\',
+		['\b'] = '\\b',
+		['\f'] = '\\f',
+		['\n'] = '\\n',
+		['\r'] = '\\r',
+		['\t'] = '\\t',
+		__index = function(_, c)
+			return format('\\u00%02X', byte(c))
+		end
+	}
+	setmetatable(f_string_subst, f_string_subst)
+
+	local function f_string(s)
+		builder[i] = '"'
+		if find(s, f_string_esc_pat) then
+			s = gsub(s, f_string_esc_pat, f_string_subst)
+		end
+		builder[i+1] = s
+		builder[i+2] = '"'
+		i = i+3
+	end
+
+	local function f_table(o)
+		if visited[o] then
+			error("loop detected")
+		end
+		visited[o] = true
+
+		local tmp = o[0]
+		if type(tmp) == 'number' then -- arraylen available
+			builder[i] = '['
+			i = i+1
+			for j = 1, tmp do
+				doencode(o[j])
+				builder[i] = ','
+				i = i+1
+			end
+			if tmp > 0 then
+				i = i-1
+			end
+			builder[i] = ']'
+
+		else
+			tmp = o[1]
+			if tmp ~= nil then -- detected as array
+				builder[i] = '['
+				i = i+1
+				local j = 2
+				repeat
+					doencode(tmp)
+					tmp = o[j]
+					if tmp == nil then
+						break
+					end
+					j = j+1
+					builder[i] = ','
+					i = i+1
+				until false
+				builder[i] = ']'
+
+			else -- detected as object
+				builder[i] = '{'
+				i = i+1
+				local tmp = i
+				for k, v in pairs(o) do
+					if type(k) ~= 'string' then
+						error("non-string key")
+					end
+					f_string(k)
+					builder[i] = ':'
+					i = i+1
+					doencode(v)
+					builder[i] = ','
+					i = i+1
+				end
+				if i > tmp then
+					i = i-1
+				end
+				builder[i] = '}'
+			end
+		end
+
+		i = i+1
+		visited[o] = nil
+	end
+
+	local dispatcher = {
+		boolean = f_tostring,
+		number = f_number,
+		string = f_string,
+		table = f_table,
+		__index = function()
+			error("invalid type value")
+		end
+	}
+	setmetatable(dispatcher, dispatcher)
+
+	function doencode(v)
+		if v == nullv then
+			builder[i] = 'null'
+			i = i+1
+			return
+		end
+		return dispatcher[type(v)](v)
+	end
+
+	local function encode(v_, nullv_)
+		v, nullv = v_, nullv_
+		i, builder, visited = 1, {}, {}
+
+		doencode(v)
+		return concat(builder)
+	end
+
+	return encode
+end
+
+return newencoder

--- a/src/lunajson/lunajson.lua
+++ b/src/lunajson/lunajson.lua
@@ -1,0 +1,11 @@
+local newdecoder = require 'lunajson.decoder'
+local newencoder = require 'lunajson.encoder'
+local sax = require 'lunajson.sax'
+-- If you need multiple contexts of decoder and/or encoder,
+-- you can require lunajson.decoder and/or lunajson.encoder directly.
+return {
+	decode = newdecoder(),
+	encode = newencoder(),
+	newparser = sax.newparser,
+	newfileparser = sax.newfileparser,
+}

--- a/src/lunajson/sax.lua
+++ b/src/lunajson/sax.lua
@@ -1,0 +1,719 @@
+local setmetatable, tonumber, tostring =
+      setmetatable, tonumber, tostring
+local floor, inf =
+      math.floor, math.huge
+local mininteger, tointeger =
+      math.mininteger or nil, math.tointeger or nil
+local byte, char, find, gsub, match, sub =
+      string.byte, string.char, string.find, string.gsub, string.match, string.sub
+
+local function _parse_error(pos, errmsg)
+	error("parse error at " .. pos .. ": " .. errmsg, 2)
+end
+
+local f_str_ctrl_pat
+if _VERSION == "Lua 5.1" then
+	-- use the cluttered pattern because lua 5.1 does not handle \0 in a pattern correctly
+	f_str_ctrl_pat = '[^\32-\255]'
+else
+	f_str_ctrl_pat = '[\0-\31]'
+end
+
+local type, unpack = type, table.unpack or unpack
+local open = io.open
+
+local _ENV = nil
+
+
+local function nop() end
+
+local function newparser(src, saxtbl)
+	local json, jsonnxt, rec_depth
+	local jsonlen, pos, acc = 0, 1, 0
+
+	-- `f` is the temporary for dispatcher[c] and
+	-- the dummy for the first return value of `find`
+	local dispatcher, f
+
+	-- initialize
+	if type(src) == 'string' then
+		json = src
+		jsonlen = #json
+		jsonnxt = function()
+			json = ''
+			jsonlen = 0
+			jsonnxt = nop
+		end
+	else
+		jsonnxt = function()
+			acc = acc + jsonlen
+			pos = 1
+			repeat
+				json = src()
+				if not json then
+					json = ''
+					jsonlen = 0
+					jsonnxt = nop
+					return
+				end
+				jsonlen = #json
+			until jsonlen > 0
+		end
+		jsonnxt()
+	end
+
+	local sax_startobject = saxtbl.startobject or nop
+	local sax_key = saxtbl.key or nop
+	local sax_endobject = saxtbl.endobject or nop
+	local sax_startarray = saxtbl.startarray or nop
+	local sax_endarray = saxtbl.endarray or nop
+	local sax_string = saxtbl.string or nop
+	local sax_number = saxtbl.number or nop
+	local sax_boolean = saxtbl.boolean or nop
+	local sax_null = saxtbl.null or nop
+
+	--[[
+		Helper
+	--]]
+	local function tryc()
+		local c = byte(json, pos)
+		if not c then
+			jsonnxt()
+			c = byte(json, pos)
+		end
+		return c
+	end
+
+	local function parse_error(errmsg)
+		return _parse_error(acc + pos, errmsg)
+	end
+
+	local function tellc()
+		return tryc() or parse_error("unexpected termination")
+	end
+
+	local function spaces()  -- skip spaces and prepare the next char
+		while true do
+			pos = match(json, '^[ \n\r\t]*()', pos)
+			if pos <= jsonlen then
+				return
+			end
+			if jsonlen == 0 then
+				parse_error("unexpected termination")
+			end
+			jsonnxt()
+		end
+	end
+
+	--[[
+		Invalid
+	--]]
+	local function f_err()
+		parse_error('invalid value')
+	end
+
+	--[[
+		Constants
+	--]]
+	-- fallback slow constants parser
+	local function generic_constant(target, targetlen, ret, sax_f)
+		for i = 1, targetlen do
+			local c = tellc()
+			if byte(target, i) ~= c then
+				parse_error("invalid char")
+			end
+			pos = pos+1
+		end
+		return sax_f(ret)
+	end
+
+	-- null
+	local function f_nul()
+		if sub(json, pos, pos+2) == 'ull' then
+			pos = pos+3
+			return sax_null(nil)
+		end
+		return generic_constant('ull', 3, nil, sax_null)
+	end
+
+	-- false
+	local function f_fls()
+		if sub(json, pos, pos+3) == 'alse' then
+			pos = pos+4
+			return sax_boolean(false)
+		end
+		return generic_constant('alse', 4, false, sax_boolean)
+	end
+
+	-- true
+	local function f_tru()
+		if sub(json, pos, pos+2) == 'rue' then
+			pos = pos+3
+			return sax_boolean(true)
+		end
+		return generic_constant('rue', 3, true, sax_boolean)
+	end
+
+	--[[
+		Numbers
+		Conceptually, the longest prefix that matches to `[-+.0-9A-Za-z]+` (in regexp)
+		is captured as a number and its conformance to the JSON spec is checked.
+	--]]
+	-- deal with non-standard locales
+	local radixmark = match(tostring(0.5), '[^0-9]')
+	local fixedtonumber = tonumber
+	if radixmark ~= '.' then
+		if find(radixmark, '%W') then
+			radixmark = '%' .. radixmark
+		end
+		fixedtonumber = function(s)
+			return tonumber(gsub(s, '.', radixmark))
+		end
+	end
+
+	local function number_error()
+		return parse_error('invalid number')
+	end
+
+	-- fallback slow parser
+	local function generic_number(mns)
+		local buf = {}
+		local i = 1
+		local is_int = true
+
+		local c = byte(json, pos)
+		pos = pos+1
+
+		local function nxt()
+			buf[i] = c
+			i = i+1
+			c = tryc()
+			pos = pos+1
+		end
+
+		if c == 0x30 then
+			nxt()
+			if c and 0x30 <= c and c < 0x3A then
+				number_error()
+			end
+		else
+			repeat nxt() until not (c and 0x30 <= c and c < 0x3A)
+		end
+		if c == 0x2E then
+			is_int = false
+			nxt()
+			if not (c and 0x30 <= c and c < 0x3A) then
+				number_error()
+			end
+			repeat nxt() until not (c and 0x30 <= c and c < 0x3A)
+		end
+		if c == 0x45 or c == 0x65 then
+			is_int = false
+			nxt()
+			if c == 0x2B or c == 0x2D then
+				nxt()
+			end
+			if not (c and 0x30 <= c and c < 0x3A) then
+				number_error()
+			end
+			repeat nxt() until not (c and 0x30 <= c and c < 0x3A)
+		end
+		if c and (0x41 <= c and c <= 0x5B or
+		          0x61 <= c and c <= 0x7B or
+		          c == 0x2B or c == 0x2D or c == 0x2E) then
+			number_error()
+		end
+		pos = pos-1
+
+		local num = char(unpack(buf))
+		num = fixedtonumber(num)
+		if mns then
+			num = -num
+			if num == mininteger and is_int then
+				num = mininteger
+			end
+		end
+		return sax_number(num)
+	end
+
+	-- `0(\.[0-9]*)?([eE][+-]?[0-9]*)?`
+	local function f_zro(mns)
+		local num, c = match(json, '^(%.?[0-9]*)([-+.A-Za-z]?)', pos)  -- skipping 0
+
+		if num == '' then
+			if pos > jsonlen then
+				pos = pos - 1
+				return generic_number(mns)
+			end
+			if c == '' then
+				if mns then
+					return sax_number(-0.0)
+				end
+				return sax_number(0)
+			end
+
+			if c == 'e' or c == 'E' then
+				num, c = match(json, '^([^eE]*[eE][-+]?[0-9]+)([-+.A-Za-z]?)', pos)
+				if c == '' then
+					pos = pos + #num
+					if pos > jsonlen then
+						pos = pos - #num - 1
+						return generic_number(mns)
+					end
+					if mns then
+						return sax_number(-0.0)
+					end
+					return sax_number(0.0)
+				end
+			end
+			pos = pos-1
+			return generic_number(mns)
+		end
+
+		if byte(num) ~= 0x2E or byte(num, -1) == 0x2E then
+			pos = pos-1
+			return generic_number(mns)
+		end
+
+		if c ~= '' then
+			if c == 'e' or c == 'E' then
+				num, c = match(json, '^([^eE]*[eE][-+]?[0-9]+)([-+.A-Za-z]?)', pos)
+			end
+			if c ~= '' then
+				pos = pos-1
+				return generic_number(mns)
+			end
+		end
+
+		pos = pos + #num
+		if pos > jsonlen then
+			pos = pos - #num - 1
+			return generic_number(mns)
+		end
+		c = fixedtonumber(num)
+
+		if mns then
+			c = -c
+		end
+		return sax_number(c)
+	end
+
+	-- `[1-9][0-9]*(\.[0-9]*)?([eE][+-]?[0-9]*)?`
+	local function f_num(mns)
+		pos = pos-1
+		local num, c = match(json, '^([0-9]+%.?[0-9]*)([-+.A-Za-z]?)', pos)
+		if byte(num, -1) == 0x2E then  -- error if ended with period
+			return generic_number(mns)
+		end
+
+		if c ~= '' then
+			if c ~= 'e' and c ~= 'E' then
+				return generic_number(mns)
+			end
+			num, c = match(json, '^([^eE]*[eE][-+]?[0-9]+)([-+.A-Za-z]?)', pos)
+			if not num or c ~= '' then
+				return generic_number(mns)
+			end
+		end
+
+		pos = pos + #num
+		if pos > jsonlen then
+			pos = pos - #num
+			return generic_number(mns)
+		end
+		c = fixedtonumber(num)
+
+		if mns then
+			c = -c
+			if c == mininteger and not find(num, '[^0-9]') then
+				c = mininteger
+			end
+		end
+		return sax_number(c)
+	end
+
+	-- skip minus sign
+	local function f_mns()
+		local c = byte(json, pos) or tellc()
+		if c then
+			pos = pos+1
+			if c > 0x30 then
+				if c < 0x3A then
+					return f_num(true)
+				end
+			else
+				if c > 0x2F then
+					return f_zro(true)
+				end
+			end
+		end
+		parse_error("invalid number")
+	end
+
+	--[[
+		Strings
+	--]]
+	local f_str_hextbl = {
+		0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
+		0x8, 0x9, inf, inf, inf, inf, inf, inf,
+		inf, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, inf,
+		inf, inf, inf, inf, inf, inf, inf, inf,
+		inf, inf, inf, inf, inf, inf, inf, inf,
+		inf, inf, inf, inf, inf, inf, inf, inf,
+		inf, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF,
+		__index = function()
+			return inf
+		end
+	}
+	setmetatable(f_str_hextbl, f_str_hextbl)
+
+	local f_str_escapetbl = {
+		['"']  = '"',
+		['\\'] = '\\',
+		['/']  = '/',
+		['b']  = '\b',
+		['f']  = '\f',
+		['n']  = '\n',
+		['r']  = '\r',
+		['t']  = '\t',
+		__index = function()
+			parse_error("invalid escape sequence")
+		end
+	}
+	setmetatable(f_str_escapetbl, f_str_escapetbl)
+
+	local function surrogate_first_error()
+		return parse_error("1st surrogate pair byte not continued by 2nd")
+	end
+
+	local f_str_surrogate_prev = 0
+	local function f_str_subst(ch, ucode)
+		if ch == 'u' then
+			local c1, c2, c3, c4, rest = byte(ucode, 1, 5)
+			ucode = f_str_hextbl[c1-47] * 0x1000 +
+			        f_str_hextbl[c2-47] * 0x100 +
+			        f_str_hextbl[c3-47] * 0x10 +
+			        f_str_hextbl[c4-47]
+			if ucode ~= inf then
+				if ucode < 0x80 then  -- 1byte
+					if rest then
+						return char(ucode, rest)
+					end
+					return char(ucode)
+				elseif ucode < 0x800 then  -- 2bytes
+					c1 = floor(ucode / 0x40)
+					c2 = ucode - c1 * 0x40
+					c1 = c1 + 0xC0
+					c2 = c2 + 0x80
+					if rest then
+						return char(c1, c2, rest)
+					end
+					return char(c1, c2)
+				elseif ucode < 0xD800 or 0xE000 <= ucode then  -- 3bytes
+					c1 = floor(ucode / 0x1000)
+					ucode = ucode - c1 * 0x1000
+					c2 = floor(ucode / 0x40)
+					c3 = ucode - c2 * 0x40
+					c1 = c1 + 0xE0
+					c2 = c2 + 0x80
+					c3 = c3 + 0x80
+					if rest then
+						return char(c1, c2, c3, rest)
+					end
+					return char(c1, c2, c3)
+				elseif 0xD800 <= ucode and ucode < 0xDC00 then  -- surrogate pair 1st
+					if f_str_surrogate_prev == 0 then
+						f_str_surrogate_prev = ucode
+						if not rest then
+							return ''
+						end
+						surrogate_first_error()
+					end
+					f_str_surrogate_prev = 0
+					surrogate_first_error()
+				else  -- surrogate pair 2nd
+					if f_str_surrogate_prev ~= 0 then
+						ucode = 0x10000 +
+						        (f_str_surrogate_prev - 0xD800) * 0x400 +
+						        (ucode - 0xDC00)
+						f_str_surrogate_prev = 0
+						c1 = floor(ucode / 0x40000)
+						ucode = ucode - c1 * 0x40000
+						c2 = floor(ucode / 0x1000)
+						ucode = ucode - c2 * 0x1000
+						c3 = floor(ucode / 0x40)
+						c4 = ucode - c3 * 0x40
+						c1 = c1 + 0xF0
+						c2 = c2 + 0x80
+						c3 = c3 + 0x80
+						c4 = c4 + 0x80
+						if rest then
+							return char(c1, c2, c3, c4, rest)
+						end
+						return char(c1, c2, c3, c4)
+					end
+					parse_error("2nd surrogate pair byte appeared without 1st")
+				end
+			end
+			parse_error("invalid unicode codepoint literal")
+		end
+		if f_str_surrogate_prev ~= 0 then
+			f_str_surrogate_prev = 0
+			surrogate_first_error()
+		end
+		return f_str_escapetbl[ch] .. ucode
+	end
+
+	local function f_str(iskey)
+		local pos2 = pos
+		local newpos
+		local str = ''
+		local bs
+		while true do
+			while true do  -- search '\' or '"'
+				newpos = find(json, '[\\"]', pos2)
+				if newpos then
+					break
+				end
+				str = str .. sub(json, pos, jsonlen)
+				if pos2 == jsonlen+2 then
+					pos2 = 2
+				else
+					pos2 = 1
+				end
+				jsonnxt()
+				if jsonlen == 0 then
+					parse_error("unterminated string")
+				end
+			end
+			if byte(json, newpos) == 0x22 then  -- break if '"'
+				break
+			end
+			pos2 = newpos+2  -- skip '\<char>'
+			bs = true  -- mark the existence of a backslash
+		end
+		str = str .. sub(json, pos, newpos-1)
+		pos = newpos+1
+
+		if find(str, f_str_ctrl_pat) then
+			parse_error("unescaped control string")
+		end
+		if bs then  -- a backslash exists
+			-- We need to grab 4 characters after the escape char,
+			-- for encoding unicode codepoint to UTF-8.
+			-- As we need to ensure that every first surrogate pair byte is
+			-- immediately followed by second one, we grab upto 5 characters and
+			-- check the last for this purpose.
+			str = gsub(str, '\\(.)([^\\]?[^\\]?[^\\]?[^\\]?[^\\]?)', f_str_subst)
+			if f_str_surrogate_prev ~= 0 then
+				f_str_surrogate_prev = 0
+				parse_error("1st surrogate pair byte not continued by 2nd")
+			end
+		end
+
+		if iskey then
+			return sax_key(str)
+		end
+		return sax_string(str)
+	end
+
+	--[[
+		Arrays, Objects
+	--]]
+	-- arrays
+	local function f_ary()
+		rec_depth = rec_depth + 1
+		if rec_depth > 1000 then
+			parse_error('too deeply nested json (> 1000)')
+		end
+		sax_startarray()
+
+		spaces()
+		if byte(json, pos) == 0x5D then  -- check closing bracket ']' which means the array empty
+			pos = pos+1
+		else
+			local newpos
+			while true do
+				f = dispatcher[byte(json, pos)]  -- parse value
+				pos = pos+1
+				f()
+				newpos = match(json, '^[ \n\r\t]*,[ \n\r\t]*()', pos)  -- check comma
+				if newpos then
+					pos = newpos
+				else
+					newpos = match(json, '^[ \n\r\t]*%]()', pos)  -- check closing bracket
+					if newpos then
+						pos = newpos
+						break
+					end
+					spaces()  -- since the current chunk can be ended, skip spaces toward following chunks
+					local c = byte(json, pos)
+					pos = pos+1
+					if c == 0x2C then  -- check comma again
+						spaces()
+					elseif c == 0x5D then  -- check closing bracket again
+						break
+					else
+						parse_error("no closing bracket of an array")
+					end
+				end
+				if pos > jsonlen then
+					spaces()
+				end
+			end
+		end
+
+		rec_depth = rec_depth - 1
+		return sax_endarray()
+	end
+
+	-- objects
+	local function f_obj()
+		rec_depth = rec_depth + 1
+		if rec_depth > 1000 then
+			parse_error('too deeply nested json (> 1000)')
+		end
+		sax_startobject()
+
+		spaces()
+		if byte(json, pos) == 0x7D then  -- check closing bracket '}' which means the object empty
+			pos = pos+1
+		else
+			local newpos
+			while true do
+				if byte(json, pos) ~= 0x22 then
+					parse_error("not key")
+				end
+				pos = pos+1
+				f_str(true)  -- parse key
+				newpos = match(json, '^[ \n\r\t]*:[ \n\r\t]*()', pos)  -- check colon
+				if newpos then
+					pos = newpos
+				else
+					spaces()  -- read spaces through chunks
+					if byte(json, pos) ~= 0x3A then  -- check colon again
+						parse_error("no colon after a key")
+					end
+					pos = pos+1
+					spaces()
+				end
+				if pos > jsonlen then
+					spaces()
+				end
+				f = dispatcher[byte(json, pos)]
+				pos = pos+1
+				f()  -- parse value
+				newpos = match(json, '^[ \n\r\t]*,[ \n\r\t]*()', pos)  -- check comma
+				if newpos then
+					pos = newpos
+				else
+					newpos = match(json, '^[ \n\r\t]*}()', pos)  -- check closing bracket
+					if newpos then
+						pos = newpos
+						break
+					end
+					spaces()  -- read spaces through chunks
+					local c = byte(json, pos)
+					pos = pos+1
+					if c == 0x2C then  -- check comma again
+						spaces()
+					elseif c == 0x7D then  -- check closing bracket again
+						break
+					else
+						parse_error("no closing bracket of an object")
+					end
+				end
+				if pos > jsonlen then
+					spaces()
+				end
+			end
+		end
+
+		rec_depth = rec_depth - 1
+		return sax_endobject()
+	end
+
+	--[[
+		The jump table to dispatch a parser for a value,
+		indexed by the code of the value's first char.
+		Key should be non-nil.
+	--]]
+	dispatcher = { [0] =
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_str, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_mns, f_err, f_err,
+		f_zro, f_num, f_num, f_num, f_num, f_num, f_num, f_num,
+		f_num, f_num, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_ary, f_err, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_fls, f_err,
+		f_err, f_err, f_err, f_err, f_err, f_err, f_nul, f_err,
+		f_err, f_err, f_err, f_err, f_tru, f_err, f_err, f_err,
+		f_err, f_err, f_err, f_obj, f_err, f_err, f_err, f_err,
+	}
+
+	--[[
+		public funcitons
+	--]]
+	local function run()
+		rec_depth = 0
+		spaces()
+		f = dispatcher[byte(json, pos)]
+		pos = pos+1
+		f()
+	end
+
+	local function read(n)
+		if n < 0 then
+			error("the argument must be non-negative")
+		end
+		local pos2 = (pos-1) + n
+		local str = sub(json, pos, pos2)
+		while pos2 > jsonlen and jsonlen ~= 0 do
+			jsonnxt()
+			pos2 = pos2 - (jsonlen - (pos-1))
+			str = str .. sub(json, pos, pos2)
+		end
+		if jsonlen ~= 0 then
+			pos = pos2+1
+		end
+		return str
+	end
+
+	local function tellpos()
+		return acc + pos
+	end
+
+	return {
+		run = run,
+		tryc = tryc,
+		read = read,
+		tellpos = tellpos,
+	}
+end
+
+local function newfileparser(fn, saxtbl)
+	local fp = open(fn)
+	local function gen()
+		local s
+		if fp then
+			s = fp:read(8192)
+			if not s then
+				fp:close()
+				fp = nil
+			end
+		end
+		return s
+	end
+	return newparser(gen, saxtbl)
+end
+
+return {
+	newparser = newparser,
+	newfileparser = newfileparser
+}

--- a/src/smufl_load_engraving_defaults.lua
+++ b/src/smufl_load_engraving_defaults.lua
@@ -3,7 +3,7 @@ function plugindef()
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
     finaleplugin.Version = "1.0"
     finaleplugin.Date = "June 18, 2021"
-    finaleplugin.CategoryTags = "Staff"
+    finaleplugin.CategoryTags = "Layout"
     return "Load SMuFL Engraving Defaults", "Load SMuFL Engraving Defaults", "Loads engraving defaults for the current SMuFL Default Music Font."
 end
 

--- a/src/smufl_load_engraving_defaults.lua
+++ b/src/smufl_load_engraving_defaults.lua
@@ -24,17 +24,163 @@ function smufl_load_engraving_defaults()
     local font_json_path = smufl_json_path .. font_info.Name .. "/" .. font_info.Name .. ".json"
     local font_json_file = io.open(font_json_path, "r")
     if nil == font_json_file then
-        finenv.UI():AlertError("The current Default Music Font is not a SMuFL font, or else the json file with its engraving defaults is not installed.", "Default Music Font is not SMuFL")
+        finenv.UI():AlertError("The current Default Music Font (" .. font_info.Name .. ") is not a SMuFL font, or else the json file with its engraving defaults is not installed.", "Default Music Font is not SMuFL")
         return
     end
     local json = font_json_file:read("*all")
     io.close(font_json_file)
-    local font_info = luna.decode(json)
-    local defaults = ""
-    for k, v in pairs(font_info.engravingDefaults) do
-        defaults = defaults .. "\n" .. k .. ":" .. v
+    local font_metadata = luna.decode(json)
+
+    local evpuPerSpace = 24.0
+    local efixPerEvpu = 64.0
+    local efixPerSpace = evpuPerSpace * efixPerEvpu
+
+    -- read our current doc options
+    local music_char_prefs = finale.FCMusicCharacterPrefs()
+    music_char_prefs:Load(1)
+    local distance_prefs = finale.FCDistancePrefs()
+    distance_prefs:Load(1)
+    local size_prefs = finale.FCSizePrefs()
+    size_prefs:Load(1)
+    local lyrics_prefs = finale.FCLyricsPrefs()
+    lyrics_prefs:Load(1)
+    local smart_shape_prefs = finale.FCSmartShapePrefs()
+    smart_shape_prefs:Load(1)
+    local repeat_prefs = finale.FCRepeatPrefs()
+    repeat_prefs:Load(1)
+    local tie_prefs = finale.FCTiePrefs()
+    tie_prefs:Load(1)
+    local tuplet_prefs = finale.FCTupletPrefs()
+    tuplet_prefs:Load(1)
+
+    -- define actions for each of the fields of font_info.engravingDefaults
+    local action = {
+        staffLineThickness = function(v) size_prefs.StaffLineThickness = math.floor(efixPerSpace*v + 0.5) end,
+        stemThickness = function(v) size_prefs.StemLineThickness = math.floor(efixPerSpace*v + 0.5) end,
+        beamThickness = function(v) size_prefs.BeamThickness = math.floor(efixPerSpace*v + 0.5) end,
+        beamSpacing = function(v) distance_prefs.SecondaryBeamSpace = math.floor(evpuPerSpace*v + 0.5) end,
+        legerLineThickness = function(v) size_prefs.LedgerLineThickness = math.floor(efixPerSpace*v + 0.5) end,
+        legerLineExtension = function(v)
+                size_prefs.LedgerLeftHalf = math.floor(evpuPerSpace*v + 0.5)
+                size_prefs.LedgerRightHalf = size_prefs.LedgerLeftHalf
+                size_prefs.LedgerLeftRestHalf = size_prefs.LedgerLeftHalf
+                size_prefs.LedgerRightRestHalf = size_prefs.LedgerLeftHalf
+            end,
+        slurEndpointThickness = function(v)
+                size_prefs.ShapeSlurTipWidth = math.floor(evpuPerSpace*v*10000.0 +0.5)
+                smart_shape_prefs.SlurTipWidth = math.floor(evpuPerSpace*v*10000.0 +0.5)
+            end,
+        slurMidpointThickness = function(v)
+                smart_shape_prefs.SlurThicknessVerticalLeft = math.floor(evpuPerSpace*v +0.5)
+                smart_shape_prefs.SlurThicknessVerticalRight = math.floor(evpuPerSpace*v +0.5)
+            end,
+        tieEndpointThickness = function(v) tie_prefs.TipWidth = math.floor(evpuPerSpace*v*10000.0 +0.5) end,
+        tieMidpointThickness = function(v)
+            tie_prefs.ThicknessLeft = math.floor(evpuPerSpace*v +0.5)
+            tie_prefs.ThicknessRight = math.floor(evpuPerSpace*v +0.5)
+        end,
+        thinBarlineThickness = function(v)
+                size_prefs.ThinBarlineThickness = math.floor(efixPerSpace*v + 0.5)
+                repeat_prefs.ThinLineThickness = math.floor(efixPerSpace*v + 0.5)
+            end,
+        thickBarlineThickness = function(v)
+                size_prefs.HeavyBarlineThickness = math.floor(efixPerSpace*v + 0.5)
+                repeat_prefs.HeavyLineThickness = math.floor(efixPerSpace*v + 0.5)
+            end,
+        dashedBarlineThickness = function(v) size_prefs.ThinBarlineThickness = math.floor(efixPerSpace*v + 0.5) end,
+        dashedBarlineDashLength = function(v) size_prefs.BarlineDashLength = math.floor(evpuPerSpace*v + 0.5) end,
+        dashedBarlineGapLength = function(v) distance_prefs.BarlineDashSpace = math.floor(evpuPerSpace*v + 0.5)end,
+        barlineSeparation = function(v) distance_prefs.BarlineDoubleSpace = math.floor(efixPerSpace*v + 0.5) end,
+        thinThickBarlineSeparation = function(v)
+                distance_prefs.BarlineFinalSpace = math.floor(efixPerSpace*v + 0.5)
+                repeat_prefs.SpaceBetweenLines = math.floor(efixPerSpace*v + 0.5)
+            end,
+        repeatBarlineDotSeparation = function(v)
+                local text_met = finale.FCTextMetrics()
+                text_met:LoadSymbol(music_char_prefs.SymbolForwardRepeatDot, font_info, 100)
+                local newVal = evpuPerSpace*v + text_met:CalcWidthEVPUs()
+                repeat_prefs:SetForwardSpace(math.floor(newVal + 0.5))
+                repeat_prefs:SetBackwardSpace(math.floor(newVal + 0.5))
+            end,
+        bracketThickness = function(v) end, -- Not supported. (Finale doesn't seem to have this pref setting.)
+        subBracketThickness = function(v) end, -- Not supported. (Finale doesn't seem to have this pref setting.)
+        hairpinThickness = function(v) smart_shape_prefs.HairpinLineWidth = math.floor(efixPerSpace*v + 0.5) end,
+        octaveLineThickness = function(v) smart_shape_prefs.LineWidth = math.floor(efixPerSpace*v + 0.5) end,
+        pedalLineThickness = function(v) end, -- To Do: requires finding and editing Custom Lines
+        repeatEndingLineThickness = function(v) repeat_prefs.EndingLineThickness = math.floor(efixPerSpace*v + 0.5) end,
+        arrowShaftThickness = function(v) end, -- To Do: requires finding and editing Custom Lines
+        lyricLineThickness = function(v) lyrics_prefs.WordExtLineThickness = math.floor(efixPerSpace*v + 0.5) end,
+        textEnclosureThickness = function(v)
+                size_prefs.EnclosureThickness = math.floor(efixPerSpace*v + 0.5)
+                local expression_defs = finale.FCTextExpressionDefs()
+                expression_defs:LoadAll()
+                for def in each(expression_defs) do
+                    if def.UseEnclosure then
+                        local enclosure = def:CreateEnclosure()
+                        if ( nil ~= enclosure) then
+                            enclosure.LineWidth = size_prefs.EnclosureThickness
+                            enclosure:Save()
+                        end
+                    end
+                end
+                local numbering_regions = finale.FCMeasureNumberRegions()
+                numbering_regions:LoadAll()
+                for region in each(numbering_regions) do
+                    local got1 = false
+                    for _, for_parts in pairs({false, true}) do
+                        if region:GetUseEnclosureStart(for_parts) then
+                            local enc_start = region:GetEnclosureStart(for_parts)
+                            if nil ~= enc_start then
+                                enc_start.LineWidth = size_prefs.EnclosureThickness
+                                got1 = true
+                            end
+                        end
+                        if region:GetUseEnclosureMultiple(for_parts) then
+                            local enc_multiple = region:GetEnclosureMultiple(for_parts)
+                            if nil ~= enc_multiple then
+                                enc_multiple.LineWidth = size_prefs.EnclosureThickness
+                                got1 = true
+                            end
+                        end
+                    end
+                    if got1 then
+                        region:Save()
+                    end
+                end
+                local separate_numbers = finale.FCSeparateMeasureNumbers()
+                separate_numbers:LoadAll()
+                for sepnum in each(separate_numbers) do
+                    if sepnum.UseEnclosure then
+                        local enc_sep = sepnum:GetEnclosure()
+                        if nil ~= enc_sep then
+                            enc_sep.LineWidth = size_prefs.EnclosureThickness
+                        end
+                        sepnum:Save()
+                    end
+                end
+            end,
+        tupletBracketThickness = function(v)
+                tuplet_prefs.BracketThickness = math.floor(efixPerSpace*v + 0.5)
+            end,
+        hBarThickness = function(v) end -- Not supported. (Can't edit FCShape in Lua. Hard even in PDK.)
+    }
+
+    -- apply each action from the json file
+    for k, v in pairs(font_metadata.engravingDefaults) do
+        local action_function = action[k]
+        if nil ~= action_function then
+            action_function(tonumber(v))
+        end
     end
-    finenv.UI():AlertInfo(defaults, "info")
+
+    -- save new preferences
+    distance_prefs:Save()
+    size_prefs:Save()
+    lyrics_prefs:Save()
+    smart_shape_prefs:Save()
+    repeat_prefs:Save()
+    tie_prefs:Save()
+    tuplet_prefs:Save()
 end
 
 smufl_load_engraving_defaults()

--- a/src/smufl_load_engraving_defaults.lua
+++ b/src/smufl_load_engraving_defaults.lua
@@ -1,0 +1,40 @@
+function plugindef()
+    finaleplugin.Author = "Robert Patterson"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "June 18, 2021"
+    finaleplugin.CategoryTags = "Staff"
+    return "Load SMuFL Engraving Defaults", "Load SMuFL Engraving Defaults", "Loads engraving defaults for the current SMuFL Default Music Font."
+end
+
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local luna = require("lunajson.lunajson")
+
+local smufl_json_path = "/Library/Application Support/SMuFL/Fonts/"
+if finenv.UI():IsOnWindows() then
+    local common_programs_path = os.getenv("COMMONPROGRAMFILES") 
+    smufl_json_path = common_programs_path .. "/SMuFL/Fonts/"
+end
+
+function smufl_load_engraving_defaults()
+    local font_info = finale.FCFontInfo()
+    font_info:LoadFontPrefs(finale.FONTPREF_MUSIC)
+    local font_json_path = smufl_json_path .. font_info.Name .. "/" .. font_info.Name .. ".json"
+    local font_json_file = io.open(font_json_path, "r")
+    if nil == font_json_file then
+        finenv.UI():AlertError("The current Default Music Font is not a SMuFL font, or else the json file with its engraving defaults is not installed.", "Default Music Font is not SMuFL")
+        return
+    end
+    local json = font_json_file:read("*all")
+    io.close(font_json_file)
+    local font_info = luna.decode(json)
+    local defaults = ""
+    for k, v in pairs(font_info.engravingDefaults) do
+        defaults = defaults .. "\n" .. k .. ":" .. v
+    end
+    finenv.UI():AlertInfo(defaults, "info")
+end
+
+smufl_load_engraving_defaults()


### PR DESCRIPTION
This pull request adds
* script ```smufl_load_engraving_defaults.lua```
* subfolder ```lunajson``` with flattened lunajson source code from [its repository](https://github.com/grafi-tt/lunajson).

The script works if downloaded in the context of the entire repo. It can't work standalone without putting lunajson in the correct place where JW Lua scripts can read it. (The default installation with ```luarocks``` does not work, unfortunately.)

This script acts as a stand-in for loading different SMuFL fonts as default font until Makemusic adds it natively in Finale.