### PR TITLE
more SMuFL support

### DIFF
--- a/src/library/notehead.lua
+++ b/src/library/notehead.lua
@@ -3,6 +3,7 @@
 local notehead = {}
 
 local configuration = require("library.configuration")
+local library = require("library.general_library")
 
 local config = {
     diamond_open                = 79,
@@ -11,6 +12,12 @@ local config = {
     diamond_whole_offset        = 5,
     diamond_breve_offset        = 14
 }
+
+-- Default to SMuFL characters for SMuFL font (without needing a config file)
+if library.is_font_smufl_font() then
+    config.diamond_open = 0xe0e1
+    config.diamond_closed = 0xe0e1  -- (in config) override to 0xe0e2 for closest matching closed diamond if you want to disregard Elain Gould and use a closed notehead
+end
 
 configuration.get_parameters("notehead.config.txt", config)
 

--- a/src/note_automatic_jete.lua
+++ b/src/note_automatic_jete.lua
@@ -18,6 +18,7 @@ package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local note_entry = require("library.note_entry")
 local articulation = require("library.articulation")
 local configuration = require("library.configuration")
+local library = require("library.general_library")
 
 local max_layers = 4            -- this should be in the PDK, but for some reason isn't
 
@@ -25,6 +26,10 @@ local config = {
     dot_character = 46,         -- ascii code for "."
     hide_last_note = false
 }
+
+if library.is_font_smufl_font() then
+    config.dot_character = 0xe4a2 -- SMuFL staccato dot above, which must be the "Main Character" in the Articulation Definition
+end
 
 configuration.get_parameters("note_automatic_jete.config.txt", config)
 

--- a/src/smufl_load_engraving_defaults.lua
+++ b/src/smufl_load_engraving_defaults.lua
@@ -10,19 +10,14 @@ end
 local path = finale.FCString()
 path:SetRunningLuaFolderPath()
 package.path = package.path .. ";" .. path.LuaString .. "?.lua"
-local luna = require("lunajson.lunajson")
 
-local smufl_json_path = "/Library/Application Support/SMuFL/Fonts/"
-if finenv.UI():IsOnWindows() then
-    local common_programs_path = os.getenv("COMMONPROGRAMFILES") 
-    smufl_json_path = common_programs_path .. "/SMuFL/Fonts/"
-end
+local luna = require("lunajson.lunajson")
+local library = require("library.general_library")
 
 function smufl_load_engraving_defaults()
     local font_info = finale.FCFontInfo()
     font_info:LoadFontPrefs(finale.FONTPREF_MUSIC)
-    local font_json_path = smufl_json_path .. font_info.Name .. "/" .. font_info.Name .. ".json"
-    local font_json_file = io.open(font_json_path, "r")
+    local font_json_file = library.get_smufl_metadata_file(font_info)
     if nil == font_json_file then
         finenv.UI():AlertError("The current Default Music Font (" .. font_info.Name .. ") is not a SMuFL font, or else the json file with its engraving defaults is not installed.", "Default Music Font is not SMuFL")
         return


### PR DESCRIPTION
This pull request
* moves smufl font checking to general_library
* adds support for the user-level directory for json files
* adds support for SMuFL diamond noteheads without the need of using a config file
* adds support for SMuFL staccato dot in automatic_jete.lua (without the need of a config file)