### PR TITLE
change staff nudgers to iterate on slots instead of staff numbers

### DIFF
--- a/src/staff_move_down.lua
+++ b/src/staff_move_down.lua
@@ -2,7 +2,7 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Nick Mazuk"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0"
+    finaleplugin.Version = "1.0.1"
     finaleplugin.Date = "June 20, 2020"
     finaleplugin.CategoryTags = "Staff"
     finaleplugin.AuthorURL = "https://nickmazuk.com"
@@ -14,26 +14,32 @@ path:SetRunningLuaFolderPath()
 package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local measurement = require("library.measurement")
 
+local single_space_evpus =  measurement.convert_to_EVPUs(tostring("1s"))
+
 function staff_move_down()
     local region = finenv.Region()
-    local start_staff = region:GetStartStaff()
-    local end_staff = region:GetEndStaff()
-    local start_measure = region:GetStartMeasure()
-
     local systems = finale.FCStaffSystems()
     systems:LoadAll()
-    local system = systems:FindMeasureNumber(start_measure)
+    local start_system = systems:FindMeasureNumber(region.StartMeasure)
+    local end_system = systems:FindMeasureNumber(region.EndMeasure)
 
-    local system_number = system:GetItemNo()
-
-    local system_staves = finale.FCSystemStaves()
-
-    system_staves:LoadAllForItem(system_number)
-    for system_staff in each(system_staves) do
-        if (system_staff.Staff + 1 > start_staff) then
-            local move_distance = math.min(system_staff.Staff - start_staff + 1, end_staff - start_staff + 1)
-            system_staff.Distance = system_staff.Distance + measurement.convert_to_EVPUs(tostring(move_distance) .. "s")
-            system_staff:Save()
+    for system_number = start_system.ItemNo, end_system.ItemNo do
+        local system_staves = finale.FCSystemStaves()
+        system_staves:LoadAllForItem(system_number)
+        local accumulated_offset = 0
+        local skipped_first = false
+        for system_staff in each(system_staves) do
+            if skipped_first then
+                if region:IsStaffIncluded(system_staff.Staff) then
+                    accumulated_offset = accumulated_offset + single_space_evpus
+                end
+                if accumulated_offset > 0 then
+                    system_staff.Distance = system_staff.Distance + accumulated_offset
+                    system_staff:Save()
+                end
+            else
+                skipped_first = true
+            end
         end
     end
 end

--- a/src/staff_move_up.lua
+++ b/src/staff_move_up.lua
@@ -2,7 +2,7 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Nick Mazuk"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0"
+    finaleplugin.Version = "1.0.1"
     finaleplugin.Date = "June 20, 2020"
     finaleplugin.CategoryTags = "Staff"
     finaleplugin.AuthorURL = "https://nickmazuk.com"
@@ -14,27 +14,32 @@ path:SetRunningLuaFolderPath()
 package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local measurement = require("library.measurement")
 
+local single_space_evpus =  measurement.convert_to_EVPUs(tostring("1s"))
+
 function staff_move_down()
     local region = finenv.Region()
-    local start_staff = region:GetStartStaff()
-    local end_staff = region:GetEndStaff()
-    local start_measure = region:GetStartMeasure()
-
     local systems = finale.FCStaffSystems()
     systems:LoadAll()
-    local system = systems:FindMeasureNumber(start_measure)
+    local start_system = systems:FindMeasureNumber(region.StartMeasure)
+    local end_system = systems:FindMeasureNumber(region.EndMeasure)
 
-    local system_number = system:GetItemNo()
-
-    local system_staves = finale.FCSystemStaves()
-
-    system_staves:LoadAllForItem(system_number)
-    for system_staff in each(system_staves) do
-        if (system_staff.Staff + 1 > start_staff) then
-            local move_distance = math.min(system_staff.Staff - start_staff + 1, end_staff - start_staff + 1)
-            system_staff.Distance = system_staff.Distance +
-                                        measurement.convert_to_EVPUs(tostring(-1 * move_distance) .. "s")
-            system_staff:Save()
+    for system_number = start_system.ItemNo, end_system.ItemNo do
+        local system_staves = finale.FCSystemStaves()
+        system_staves:LoadAllForItem(system_number)
+        local accumulated_offset = 0
+        local skipped_first = false
+        for system_staff in each(system_staves) do
+            if skipped_first then
+                if region:IsStaffIncluded(system_staff.Staff) then
+                    accumulated_offset = accumulated_offset + single_space_evpus
+                end
+                if accumulated_offset > 0 then
+                    system_staff.Distance = system_staff.Distance - accumulated_offset
+                    system_staff:Save()
+                end
+            else
+                skipped_first = true
+            end
         end
     end
 end

--- a/src/system_move_down.lua
+++ b/src/system_move_down.lua
@@ -14,7 +14,7 @@ path:SetRunningLuaFolderPath()
 package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local measurement = require("library.measurement")
 
-function system_move_up()
+function system_move_down()
     local region = finenv.Region()
     local systems = finale.FCStaffSystems()
     systems:LoadAll()
@@ -33,5 +33,5 @@ function system_move_up()
     end
 end
 
-system_move_up()
+system_move_down()
 


### PR DESCRIPTION
This pull request contains the following changes:

- Changes staff nudgers to iterate from FCSystemStaves instead of by staff number
- Iterates all selected systems
- Renames an enclosing function to match its file name (per our conventions)
- Ignore top staff in each system. The Finale UI appears to keep those at zero, so we should probably do the same.

The behavior of the functions (other than being multisystem) is compatible with the previous versions for documents where the staff numbers were in order and consecutively numbered.

resolves #85