### PR TITLE
add chord accidental adjustment scripts

### DIFF
--- a/src/chord_accidental_adjust_down.lua
+++ b/src/chord_accidental_adjust_down.lua
@@ -1,0 +1,30 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Michael McClennan"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "August 14, 2021"
+    finaleplugin.AuthorURL = "www.michaelmcclennan.com"
+    finaleplugin.AuthorEmail = "info@michaelmcclennan.com"
+    finaleplugin.CategoryTags = "Chord"
+    return "Chord Accidental - Move Down", "Adjust Chord Accidental Down", "Adjust the accidental of chord symbol down"
+end
+
+function chord_accidental_adjust_down()
+    local chordprefs = finale.FCChordPrefs()
+    chordprefs:Load(1)
+    local my_distance_result_flat = chordprefs:GetFlatBaselineAdjustment()
+    local my_distance_result_sharp = chordprefs:GetSharpBaselineAdjustment()
+    local my_distance_result_natural = chordprefs:GetNaturalBaselineAdjustment()
+    local my_distance = -5
+    local chordprefs = finale.FCChordPrefs()
+    chordprefs:Load(1)
+    chordprefs:GetFlatBaselineAdjustment()
+    chordprefs.FlatBaselineAdjustment = my_distance + my_distance_result_flat
+    chordprefs:GetSharpBaselineAdjustment()
+    chordprefs.SharpBaselineAdjustment = my_distance + my_distance_result_sharp
+    chordprefs:GetNaturalBaselineAdjustment()
+    chordprefs.NaturalBaselineAdjustment = my_distance + my_distance_result_natural
+    chordprefs:Save()
+end
+
+chord_accidental_adjust_down()

--- a/src/chord_accidental_adjust_down.lua
+++ b/src/chord_accidental_adjust_down.lua
@@ -16,7 +16,7 @@ package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local configuration = require("library.configuration")
 local config = {vertical_increment = 5}
 
-configuration.get_parameters("note_automatic_jete.config.txt", config)
+configuration.get_parameters("chord_accidental_adjust.config.txt", config)
 
 function chord_accidental_adjust_down()
     local chordprefs = finale.FCChordPrefs()

--- a/src/chord_accidental_adjust_down.lua
+++ b/src/chord_accidental_adjust_down.lua
@@ -9,21 +9,29 @@ function plugindef()
     return "Chord Accidental - Move Down", "Adjust Chord Accidental Down", "Adjust the accidental of chord symbol down"
 end
 
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+
+local configuration = require("library.configuration")
+local config = {vertical_increment = 5}
+
+configuration.get_parameters("note_automatic_jete.config.txt", config)
+
 function chord_accidental_adjust_down()
     local chordprefs = finale.FCChordPrefs()
     chordprefs:Load(1)
     local my_distance_result_flat = chordprefs:GetFlatBaselineAdjustment()
     local my_distance_result_sharp = chordprefs:GetSharpBaselineAdjustment()
     local my_distance_result_natural = chordprefs:GetNaturalBaselineAdjustment()
-    local my_distance = -5
     local chordprefs = finale.FCChordPrefs()
     chordprefs:Load(1)
     chordprefs:GetFlatBaselineAdjustment()
-    chordprefs.FlatBaselineAdjustment = my_distance + my_distance_result_flat
+    chordprefs.FlatBaselineAdjustment = -1 * config.vertical_increment + my_distance_result_flat
     chordprefs:GetSharpBaselineAdjustment()
-    chordprefs.SharpBaselineAdjustment = my_distance + my_distance_result_sharp
+    chordprefs.SharpBaselineAdjustment = -1 * config.vertical_increment + my_distance_result_sharp
     chordprefs:GetNaturalBaselineAdjustment()
-    chordprefs.NaturalBaselineAdjustment = my_distance + my_distance_result_natural
+    chordprefs.NaturalBaselineAdjustment = -1 * config.vertical_increment + my_distance_result_natural
     chordprefs:Save()
 end
 

--- a/src/chord_accidental_adjust_up.lua
+++ b/src/chord_accidental_adjust_up.lua
@@ -9,21 +9,29 @@ function plugindef()
     return "Chord Accidental - Move Down", "Adjust Chord Accidental Down", "Adjust the accidental of chord symbol down"
 end
 
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+
+local configuration = require("library.configuration")
+local config = {vertical_increment = 5}
+
+configuration.get_parameters("note_automatic_jete.config.txt", config)
+
 function chord_accidental_adjust_up()
     local chordprefs = finale.FCChordPrefs()
     chordprefs:Load(1)
     local my_distance_result_flat = chordprefs:GetFlatBaselineAdjustment()
     local my_distance_result_sharp = chordprefs:GetSharpBaselineAdjustment()
     local my_distance_result_natural = chordprefs:GetNaturalBaselineAdjustment()
-    local my_distance = 5
     local chordprefs = finale.FCChordPrefs()
     chordprefs:Load(1)
     chordprefs:GetFlatBaselineAdjustment()
-    chordprefs.FlatBaselineAdjustment = my_distance + my_distance_result_flat
+    chordprefs.FlatBaselineAdjustment = config.vertical_increment + my_distance_result_flat
     chordprefs:GetSharpBaselineAdjustment()
-    chordprefs.SharpBaselineAdjustment = my_distance + my_distance_result_sharp
+    chordprefs.SharpBaselineAdjustment = config.vertical_increment + my_distance_result_sharp
     chordprefs:GetNaturalBaselineAdjustment()
-    chordprefs.NaturalBaselineAdjustment = my_distance + my_distance_result_natural
+    chordprefs.NaturalBaselineAdjustment = config.vertical_increment + my_distance_result_natural
     chordprefs:Save()
 end
 

--- a/src/chord_accidental_adjust_up.lua
+++ b/src/chord_accidental_adjust_up.lua
@@ -1,0 +1,30 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Michael McClennan"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "August 14, 2021"
+    finaleplugin.AuthorURL = "www.michaelmcclennan.com"
+    finaleplugin.AuthorEmail = "info@michaelmcclennan.com"
+    finaleplugin.CategoryTags = "Chord"
+    return "Chord Accidental - Move Down", "Adjust Chord Accidental Down", "Adjust the accidental of chord symbol down"
+end
+
+function chord_accidental_adjust_up()
+    local chordprefs = finale.FCChordPrefs()
+    chordprefs:Load(1)
+    local my_distance_result_flat = chordprefs:GetFlatBaselineAdjustment()
+    local my_distance_result_sharp = chordprefs:GetSharpBaselineAdjustment()
+    local my_distance_result_natural = chordprefs:GetNaturalBaselineAdjustment()
+    local my_distance = 5
+    local chordprefs = finale.FCChordPrefs()
+    chordprefs:Load(1)
+    chordprefs:GetFlatBaselineAdjustment()
+    chordprefs.FlatBaselineAdjustment = my_distance + my_distance_result_flat
+    chordprefs:GetSharpBaselineAdjustment()
+    chordprefs.SharpBaselineAdjustment = my_distance + my_distance_result_sharp
+    chordprefs:GetNaturalBaselineAdjustment()
+    chordprefs.NaturalBaselineAdjustment = my_distance + my_distance_result_natural
+    chordprefs:Save()
+end
+
+chord_accidental_adjust_up()

--- a/src/chord_accidental_adjust_up.lua
+++ b/src/chord_accidental_adjust_up.lua
@@ -16,7 +16,7 @@ package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local configuration = require("library.configuration")
 local config = {vertical_increment = 5}
 
-configuration.get_parameters("note_automatic_jete.config.txt", config)
+configuration.get_parameters("chord_accidental_adjust.config.txt", config)
 
 function chord_accidental_adjust_up()
     local chordprefs = finale.FCChordPrefs()


### PR DESCRIPTION
Adds two scripts that Michael McClennan email me that adjust accidentals on chord symbols vertically.

For instance, if with the chord tool, you add a Db7 chord then run the `chord_accidental_adjust_up` script, the `b` will move up a tiny bit.

According to Michael, it works well adjusting these accidentals after batch-replacing fonts.