### PR TITLE
Rgp/bug fixes 2

### DIFF
--- a/src/library/enigma_string.lua
+++ b/src/library/enigma_string.lua
@@ -194,7 +194,7 @@ function enigma_string.calc_text_advance_width(inp_string)
             fcstring.LuaString = str.LuaString
             fcstring:TrimEnigmaTags()
             text_met:LoadString(fcstring, font_info, 100)
-            accumulated_width = accumulated_width + text_met:CalcWidthEVPUs()
+            accumulated_width = accumulated_width + text_met:GetAdvanceWidthEVPUs()
         end
     end
     return accumulated_width

--- a/src/library/note_entry.lua
+++ b/src/library/note_entry.lua
@@ -304,6 +304,30 @@ function note_entry.duplicate_note(note)
 end
 
 --[[
+% delete_note(note)
+
+@ note (FCNote)
+: (boolean) true if success
+]]
+function note_entry.delete_note(note)
+    local entry = note.Entry
+    if nil == entry then
+        return false
+    end
+
+    -- attempt to delete all associated entry-detail mods, but ignore any failures
+    finale.FCAccidentalMod():EraseAt(note)
+    finale.FCCrossStaffMod():EraseAt(note)
+    finale.FCDotMod():EraseAt(note)
+    finale.FCNoteheadMod():EraseAt(note)
+    finale.FCPercussionNoteMod():EraseAt(note)
+    finale.FCTablatureNoteMod():EraseAt(note)
+    --finale.FCTieMod():EraseAt(note)  -- FCTieMod is not currently lua supported, but leave this here in case it ever is
+
+    return entry:DeleteNote(note)
+end
+
+--[[
 % calc_spans_number_of_octaves(entry)
 
 Calculates the numer of octaves spanned by a chord (considering only staff positions, not accidentals).

--- a/src/library/note_entry.lua
+++ b/src/library/note_entry.lua
@@ -306,6 +306,8 @@ end
 --[[
 % delete_note(note)
 
+Removes the specified FCNote from its associated FCNoteEntry.
+
 @ note (FCNote)
 : (boolean) true if success
 ]]

--- a/src/library/notehead.lua
+++ b/src/library/notehead.lua
@@ -1,3 +1,7 @@
+--[[
+$module Notehead
+]]
+
 -- A collection of helpful JW Lua notehead scripts
 -- Simply import this file to another Lua script to use any of these scripts
 local notehead = {}
@@ -21,6 +25,16 @@ end
 
 configuration.get_parameters("notehead.config.txt", config)
 
+--[[
+% change_shape(note, shape)
+
+Changes the given notehead to a specified notehead descriptor string. Currently only supports "diamond".
+
+@ note (FCNote)
+@ shape (lua string)
+
+: (FCNoteheadMod) the new notehead mod record created
+]]
 function notehead.change_shape(note, shape)
     local notehead = finale.FCNoteheadMod()
     notehead:EraseAt(newnote)

--- a/src/note_cluster_determinate.lua
+++ b/src/note_cluster_determinate.lua
@@ -8,6 +8,11 @@ function plugindef()
     return "Cluster - Determinate", "Cluster - Determinate", "Creates a determinate cluster."
 end
 
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local note_entry = require("library.note_entry")
+
 local region = finenv.Region()
 
 local layer_one_note = {}
@@ -137,7 +142,7 @@ end
 function delete_bottom_notes(entry)
     while entry.Count > 1 do
         local lowest_note = entry:CalcLowestNote(nil)
-        entry:DeleteNote(lowest_note)
+        note_entry.delete_note(lowest_note)
     end
 end
 
@@ -145,16 +150,16 @@ end
 function delete_top_notes(entry)
     while entry.Count > 1 do
         local highest_note = entry:CalcHighestNote(nil)
-        entry:DeleteNote(highest_note)
+        note_entry.delete_note(highest_note)
     end
 end
 
 -- Function 6 - Delete the Top and Bottom Notes
 function delete_top_bottom_notes(entry)
     local highest_note = entry:CalcHighestNote(nil)
-    entry:DeleteNote(highest_note)
+    note_entry.delete_note(highest_note)
     local lowest_note = entry:CalcLowestNote(nil)
-    entry:DeleteNote(lowest_note)
+    note_entry.delete_note(lowest_note)
 end
 
 -- Function 6.1 - Delete the middle notes
@@ -167,7 +172,7 @@ function delete_middle_notes(entry)
         end
         for note in each(entry) do
             if note.NoteID == 2 then
-                entry:DeleteNote(note)
+                note_entry.delete_note(note)
             end
         end
     end

--- a/src/notehead_delete_duplicates.lua
+++ b/src/notehead_delete_duplicates.lua
@@ -8,6 +8,11 @@ function plugindef()
     return "Delete Duplicate Noteheads", "Delete Duplicate Noteheads", "Removes duplicate noteheads from chords and adjusts ties as needed."
 end
 
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local note_entry = require("library.note_entry")
+
 -- This script was a request from the Facebook Finale Powerusers group.
 -- I believe it is mainly useful for cleaning up after a MIDI file import.
 
@@ -32,7 +37,7 @@ function notehead_delete_duplicates()
                         note_list[pitch].AccidentalParentheses = true
                     end
                 end
-                entry:DeleteNote(note)
+                note_entry.delete_note(note)
             end
         end
     end    

--- a/src/pitch_entry_delete_bottom_note.lua
+++ b/src/pitch_entry_delete_bottom_note.lua
@@ -10,11 +10,16 @@ function plugindef()
            "Deletes the bottom note of every chord"
 end
 
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local note_entry = require("library.note_entry")
+
 function pitch_entry_delete_bottom_note()
     for entry in eachentrysaved(finenv.Region()) do
         if (entry.Count >= 2) then
             local bottom_note = entry:CalcLowestNote(nil)
-            entry:DeleteNote(bottom_note)
+            note_entry.delete_note(bottom_note)
         end
     end
 end

--- a/src/pitch_entry_delete_top_note.lua
+++ b/src/pitch_entry_delete_top_note.lua
@@ -9,11 +9,16 @@ function plugindef()
     return "Chord Line - Delete Top Note", "Chord Line - Delete Top Note", "Deletes the top note of every chord"
 end
 
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local note_entry = require("library.note_entry")
+
 function pitch_entry_delete_top_note()
     for entry in eachentrysaved(finenv.Region()) do
         if (entry.Count >= 2) then
             local top_note = entry:CalcHighestNote(nil)
-            entry:DeleteNote(top_note)
+            note_entry.delete_note(top_note)
         end
     end
 end

--- a/src/pitch_entry_keep_bottom_note.lua
+++ b/src/pitch_entry_keep_bottom_note.lua
@@ -10,11 +10,16 @@ function plugindef()
            "Keeps the bottom note of every chord and deletes the rest"
 end
 
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local note_entry = require("library.note_entry")
+
 function pitch_entry_keep_bottom_note()
     for entry in eachentrysaved(finenv.Region()) do
         while (entry.Count >= 2) do
             local top_note = entry:CalcHighestNote(nil)
-            entry:DeleteNote(top_note)
+            note_entry.delete_note(top_note)
         end
     end
 end

--- a/src/pitch_entry_keep_top_note.lua
+++ b/src/pitch_entry_keep_top_note.lua
@@ -10,11 +10,16 @@ function plugindef()
            "Keeps the top note of every chord and deletes the rest"
 end
 
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local note_entry = require("library.note_entry")
+
 function pitch_entry_keep_top_note()
     for entry in eachentrysaved(finenv.Region()) do
         while (entry.Count >= 2) do
             local bottom_note = entry:CalcLowestNote(nil)
-            entry:DeleteNote(bottom_note)
+            note_entry.delete_note(bottom_note)
         end
     end
 end


### PR DESCRIPTION
- use correct text metrics call for calculating text width
- move all calls of DeleteNote to a library function, so that we can also delete associated notehead modifications
- add documentation comments for library/notehead.lua
