### PR TITLE
add script to simplify accidentals

### DIFF
--- a/src/accidental_simplify.lua
+++ b/src/accidental_simplify.lua
@@ -17,9 +17,9 @@ local transposition = require("library.transposition")
 function accidentals_simplify()
     for entry in eachentrysaved(finenv.Region()) do
         local measure_number = entry.Measure
-        local measure = finale.FCMeasure()
-        measure:Load(measure_number)
-        local key_signature = measure:GetKeySignature()
+        local staff_number = entry.Staff
+        local cell = finale.FCCell(measure_number, staff_number)
+        local key_signature = cell:GetKeySignature()
 
         for note in each(entry) do
 

--- a/src/accidental_simplify.lua
+++ b/src/accidental_simplify.lua
@@ -1,0 +1,44 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Nick Mazuk"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "August 22, 2021"
+    finaleplugin.CategoryTags = "Accidental"
+    finaleplugin.AuthorURL = "https://nickmazuk.com"
+    return "Simplify accidentals", "Simplify accidentals", "Removes all double sharps and flats by respelling them"
+end
+
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local transposition = require("library.transposition")
+
+function accidentals_simplify()
+    for entry in eachentrysaved(finenv.Region()) do
+        local measure_number = entry.Measure
+        local measure = finale.FCMeasure()
+        measure:Load(measure_number)
+        local key_signature = measure:GetKeySignature()
+
+        for note in each(entry) do
+
+            -- Use note_string rather than note.RaiseLower because
+            -- with key signatures, note.RaiseLower returns the alteration
+            -- from the key signature, not the actual accidental.
+            -- For instance, in the key of A, a Gb has a RaiseLower of -2
+            -- even though Gb is not a double flat.
+
+            local fs_note_string = finale.FCString()
+            note:GetString(fs_note_string, key_signature, false, false)
+            local note_string = fs_note_string:GetLuaString()
+
+            -- checking for 'bb' and '##' will also match triple sharps and flats
+            if string.match(note_string, "bb") or string.match(note_string, "##") then
+                transposition.chromatic_transpose(note, 0, 0, true)
+            end
+        end
+    end
+end
+
+accidentals_simplify()


### PR DESCRIPTION
Adds a script to simplify double sharps and flats as suggested by Jon Burr in this [Facebook post](https://www.facebook.com/groups/finalescript/permalink/1889108927934030/). Note: this is not a rehash of Utilities > Respell Notes as that also simplifies single sharps and flats if they don't comply with the key signature.