### PR TITLE
Rgp changes for rgplua 0.58

### DIFF
--- a/src/library/transposition.lua
+++ b/src/library/transposition.lua
@@ -66,9 +66,9 @@ end
 local get_key_info = function(key)
     local number_of_steps = standard_key_number_of_steps
     local diatonic_steps = standard_key_major_diatonic_steps
-    if finenv.IsRGPLua and key.CalcChromaticSteps then -- if this version of RGP Lua supports custom key sigs
-        number_of_steps = key:CalcChromaticSteps()
-        diatonic_steps = key:CalcDiatonicSteps()
+    if finenv.IsRGPLua and key.CalcTotalChromaticSteps then -- if this version of RGP Lua supports custom key sigs
+        number_of_steps = key:CalcTotalChromaticSteps()
+        diatonic_steps = key:CalcDiatonicStepsMap()
     else
         if not key:IsPredefined() then
             number_of_steps = custom_key_sig_config.number_of_steps
@@ -79,7 +79,7 @@ local get_key_info = function(key)
     end
     -- 0.5849625 is log(3/2)/log(2), which is how to calculate the 5th per Ere Lievonen.
     -- For basically any practical key sig this calculation comes out to the 5th scale degree,
-    -- which is 7 steps for standard keys
+    -- which is 7 chromatic steps for standard keys
     local fifth_steps = math.floor((number_of_steps * 0.5849625) + 0.5)
     return number_of_steps, diatonic_steps, fifth_steps
 end

--- a/src/library/transposition.lua
+++ b/src/library/transposition.lua
@@ -1,7 +1,14 @@
 --[[
 $module Transposition
 
-A collection of helpful JW Lua transposition scripts
+A collection of helpful JW Lua transposition scripts.
+
+This library allows configuration of custom key signatures by means
+of a configuration file called "custom_key_sig.config.txt" in the
+"script_settings" subdirectory. However, RGP Lua (starting with version 0.58)
+can read the correct custom key signature information directly from
+Finale. Therefore, when you run this script with RGP Lua 0.58+, the configuration file
+is ignored.
 ]] -- 
 -- Structure
 -- 1. Helper functions
@@ -59,11 +66,16 @@ end
 local get_key_info = function(key)
     local number_of_steps = standard_key_number_of_steps
     local diatonic_steps = standard_key_major_diatonic_steps
-    if not key:IsPredefined() then
-        number_of_steps = custom_key_sig_config.number_of_steps
-        diatonic_steps = custom_key_sig_config.diatonic_steps
-    elseif key:IsMinor() then
-        diatonic_steps = standard_key_minor_diatonic_steps
+    if finenv.IsRGPLua and key.CalcChromaticSteps then -- if this version of RGP Lua supports custom key sigs
+        number_of_steps = key:CalcChromaticSteps()
+        diatonic_steps = key:CalcDiatonicSteps()
+    else
+        if not key:IsPredefined() then
+            number_of_steps = custom_key_sig_config.number_of_steps
+            diatonic_steps = custom_key_sig_config.diatonic_steps
+        elseif key:IsMinor() then
+            diatonic_steps = standard_key_minor_diatonic_steps
+        end
     end
     -- 0.5849625 is log(3/2)/log(2), which is how to calculate the 5th per Ere Lievonen.
     -- For basically any practical key sig this calculation comes out to the 5th scale degree,


### PR DESCRIPTION
This pull request changes the `transposition.lua` library to get accurate custom key signature information from the document, using the new functions introduced in `RGP Lua v0.58`. It continues to work the same as before with earlier versions of `RGP Lua` and with `JW Lua`.